### PR TITLE
Fix ranged damage bug; show ranged/melee damage toggle for Axes

### DIFF
--- a/client/common/utils.tsx
+++ b/client/common/utils.tsx
@@ -1221,3 +1221,21 @@ export const getCanonicalUrl = (customSet?: customSet | null) => {
   }
   return 'https://dofuslab.io';
 };
+
+export const getInitialRangedState = (
+  meleeOnly: boolean,
+  rangedOnly: boolean,
+  statsFromCustomSet: StatsFromCustomSet | null,
+) => {
+  let initialShowRanged = false;
+  if (rangedOnly) {
+    initialShowRanged = true;
+  } else if (meleeOnly) {
+    initialShowRanged = false;
+  } else if (statsFromCustomSet) {
+    initialShowRanged =
+      getStatWithDefault(statsFromCustomSet, Stat.PCT_RANGED_DAMAGE) >=
+      getStatWithDefault(statsFromCustomSet, Stat.PCT_MELEE_DAMAGE);
+  }
+  return initialShowRanged;
+};

--- a/client/common/wrappers.tsx
+++ b/client/common/wrappers.tsx
@@ -12,7 +12,7 @@ import {
   blue6,
   gray6,
 } from './mixins';
-import { Skeleton } from 'antd';
+import { Skeleton, Switch } from 'antd';
 import { set_bonuses } from 'graphql/fragments/__generated__/set';
 import { TFunction } from 'next-i18next';
 import { useTranslation } from 'i18n';
@@ -35,8 +35,15 @@ import { item_weaponStats } from 'graphql/fragments/__generated__/item';
 import { TTheme } from './themes';
 import Card from 'components/common/Card';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCube } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCube,
+  faPeopleArrows,
+  faFistRaised,
+} from '@fortawesome/free-solid-svg-icons';
 import { customSet } from 'graphql/fragments/__generated__/customSet';
+import { mq } from './constants';
+import Tooltip from 'components/common/Tooltip';
+import { Media } from 'components/common/Media';
 
 interface IResponsiveGrid {
   readonly numColumns: ReadonlyArray<number>;
@@ -354,5 +361,56 @@ export const CustomSetHead: React.FC<{ customSet?: customSet | null }> = ({
       />
       <meta property="twitter:url" content={getCanonicalUrl(customSet)} />
     </Head>
+  );
+};
+
+export const DamageTypeToggle: React.FC<{
+  readonly showRanged: boolean;
+  readonly setShowRanged: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({ showRanged, setShowRanged }) => {
+  const { t } = useTranslation('weapon_spell_effect');
+  const theme = useTheme<TTheme>();
+
+  const toggleSwitch = (
+    <Switch
+      checked={showRanged}
+      onChange={setShowRanged}
+      css={{
+        background: theme.switch?.background,
+        '.ant-switch-inner': {
+          color: theme.text?.default,
+        },
+        '&::after': {
+          background: theme.switch?.button,
+        },
+      }}
+      checkedChildren={<FontAwesomeIcon icon={faPeopleArrows} />}
+      unCheckedChildren={<FontAwesomeIcon icon={faFistRaised} />}
+    />
+  );
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        marginBottom: 8,
+      }}
+    >
+      <span css={{ marginRight: 8, [mq[1]]: { display: 'none' } }}>
+        {t('MELEE')}
+      </span>
+      <Media lessThan="xs">{toggleSwitch}</Media>
+      <Media greaterThanOrEqual="xs">
+        <Tooltip
+          title={showRanged ? t('RANGED') : t('MELEE')}
+          getPopupContainer={element => element.parentElement!}
+        >
+          {toggleSwitch}
+        </Tooltip>
+      </Media>
+      <span css={{ marginLeft: 8, [mq[1]]: { display: 'none' } }}>
+        {t('RANGED')}
+      </span>
+    </div>
   );
 };

--- a/client/components/common/SpellCard.tsx
+++ b/client/components/common/SpellCard.tsx
@@ -64,12 +64,19 @@ const SpellCard: React.FC<IProps> = ({ spell, customSet }) => {
   const rangedOnly = spellStats?.minRange && spellStats?.minRange > 1;
   const meleeOnly = !spellStats?.maxRange || spellStats?.maxRange <= 1;
 
-  const [showRanged, setShowRanged] = React.useState(
-    meleeOnly || !statsFromCustomSet
-      ? false
-      : getStatWithDefault(statsFromCustomSet, Stat.PCT_RANGED_DAMAGE) >=
-          getStatWithDefault(statsFromCustomSet, Stat.PCT_MELEE_DAMAGE),
-  );
+  let initialShowRanged = false;
+
+  if (rangedOnly) {
+    initialShowRanged = true;
+  } else if (meleeOnly) {
+    initialShowRanged = false;
+  } else if (statsFromCustomSet) {
+    initialShowRanged =
+      getStatWithDefault(statsFromCustomSet, Stat.PCT_RANGED_DAMAGE) >=
+      getStatWithDefault(statsFromCustomSet, Stat.PCT_MELEE_DAMAGE);
+  }
+
+  const [showRanged, setShowRanged] = React.useState(initialShowRanged);
 
   const damageTypeKey = showRanged ? 'ranged' : 'melee';
 

--- a/client/components/common/SpellCard.tsx
+++ b/client/components/common/SpellCard.tsx
@@ -6,7 +6,7 @@ import {
   classById_classById_spellVariantPairs_spells,
   classById_classById_spellVariantPairs_spells_spellStats,
 } from 'graphql/queries/__generated__/classById';
-import { Radio, Divider, Switch } from 'antd';
+import { Radio, Divider } from 'antd';
 import { RadioChangeEvent } from 'antd/lib/radio';
 import { useTheme } from 'emotion-theming';
 
@@ -15,6 +15,7 @@ import {
   CardTitleWithLevel,
   damageHeaderStyle,
   EffectLine,
+  DamageTypeToggle,
 } from 'common/wrappers';
 import { itemCardStyle } from 'common/mixins';
 import { customSet } from 'graphql/fragments/__generated__/customSet';
@@ -24,16 +25,10 @@ import {
   getSimpleEffect,
   calcEffect,
   getStatsFromCustomSet,
+  getInitialRangedState,
 } from 'common/utils';
 import { TEffectLine } from 'common/types';
 import { Stat } from '__generated__/globalTypes';
-import { mq } from 'common/constants';
-import { Media } from './Media';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  faFistRaised,
-  faPeopleArrows,
-} from '@fortawesome/free-solid-svg-icons';
 import Card from 'components/common/Card';
 import Tooltip from 'components/common/Tooltip';
 
@@ -61,22 +56,12 @@ const SpellCard: React.FC<IProps> = ({ spell, customSet }) => {
     | classById_classById_spellVariantPairs_spells_spellStats
     | undefined = spell.spellStats[selectedSpellLevelIdx];
 
-  const rangedOnly = spellStats?.minRange && spellStats?.minRange > 1;
+  const rangedOnly = !!spellStats?.minRange && spellStats?.minRange > 1;
   const meleeOnly = !spellStats?.maxRange || spellStats?.maxRange <= 1;
 
-  let initialShowRanged = false;
-
-  if (rangedOnly) {
-    initialShowRanged = true;
-  } else if (meleeOnly) {
-    initialShowRanged = false;
-  } else if (statsFromCustomSet) {
-    initialShowRanged =
-      getStatWithDefault(statsFromCustomSet, Stat.PCT_RANGED_DAMAGE) >=
-      getStatWithDefault(statsFromCustomSet, Stat.PCT_MELEE_DAMAGE);
-  }
-
-  const [showRanged, setShowRanged] = React.useState(initialShowRanged);
+  const [showRanged, setShowRanged] = React.useState(
+    getInitialRangedState(meleeOnly, rangedOnly, statsFromCustomSet),
+  );
 
   const damageTypeKey = showRanged ? 'ranged' : 'melee';
 
@@ -215,24 +200,6 @@ const SpellCard: React.FC<IProps> = ({ spell, customSet }) => {
       spellCharacteristics.push(t('COOLDOWN', { count: spellStats.cooldown }));
     }
 
-    const toggleSwitch = (
-      <Switch
-        checked={showRanged}
-        onChange={setShowRanged}
-        css={{
-          background: theme.switch?.background,
-          '.ant-switch-inner': {
-            color: theme.text?.default,
-          },
-          '&::after': {
-            background: theme.switch?.button,
-          },
-        }}
-        checkedChildren={<FontAwesomeIcon icon={faPeopleArrows} />}
-        unCheckedChildren={<FontAwesomeIcon icon={faFistRaised} />}
-      />
-    );
-
     content = (
       <>
         <div>
@@ -254,28 +221,10 @@ const SpellCard: React.FC<IProps> = ({ spell, customSet }) => {
           <>
             <Divider css={{ margin: '12px 0' }} />
             {showToggle && (
-              <div
-                css={{
-                  display: 'flex',
-                  marginBottom: 8,
-                }}
-              >
-                <span css={{ marginRight: 8, [mq[1]]: { display: 'none' } }}>
-                  {t('MELEE')}
-                </span>
-                <Media lessThan="xs">{toggleSwitch}</Media>
-                <Media greaterThanOrEqual="xs">
-                  <Tooltip
-                    title={showRanged ? t('RANGED') : t('MELEE')}
-                    getPopupContainer={element => element.parentElement!}
-                  >
-                    {toggleSwitch}
-                  </Tooltip>
-                </Media>
-                <span css={{ marginLeft: 8, [mq[1]]: { display: 'none' } }}>
-                  {t('RANGED')}
-                </span>
-              </div>
+              <DamageTypeToggle
+                setShowRanged={setShowRanged}
+                showRanged={showRanged}
+              />
             )}
             <div
               css={{

--- a/client/components/common/WeaponDamage.tsx
+++ b/client/components/common/WeaponDamage.tsx
@@ -11,6 +11,7 @@ import {
   CardTitleWithLevel,
   damageHeaderStyle,
   EffectLine,
+  DamageTypeToggle,
 } from 'common/wrappers';
 import { itemCardStyle } from 'common/mixins';
 import { item_weaponStats } from 'graphql/fragments/__generated__/item';
@@ -22,6 +23,7 @@ import {
   calcEffect,
   calcElementMage,
   elementMageToWeaponEffect,
+  getInitialRangedState,
 } from 'common/utils';
 import { StatsFromCustomSet, TEffectLine } from 'common/types';
 import {
@@ -56,8 +58,20 @@ const WeaponDamage: React.FC<IProps> = ({
     [setWeaponSkillPower],
   );
 
-  const rangedOnly = weaponStats.minRange && weaponStats.minRange > 1;
-  const damageTypeKey = rangedOnly ? 'ranged' : 'melee';
+  const rangedOnly = !!weaponStats.minRange && weaponStats.minRange > 1;
+  const meleeOnly =
+    !rangedOnly &&
+    !customSet.equippedItems.some(
+      equippedItem => equippedItem.item.itemType.enName === 'Axe',
+    );
+
+  const showToggle = !rangedOnly && !meleeOnly;
+
+  const [showRanged, setShowRanged] = React.useState(
+    getInitialRangedState(meleeOnly, rangedOnly, statsFromCustomSet),
+  );
+
+  const damageTypeKey = showRanged ? 'ranged' : 'melee';
   let critRate =
     typeof weaponStats.baseCritChance === 'number'
       ? getStatWithDefault(statsFromCustomSet, Stat.CRITICAL) +
@@ -224,6 +238,12 @@ const WeaponDamage: React.FC<IProps> = ({
         </Radio>
       </Radio.Group>
       <Divider css={{ margin: '12px 0' }} />
+      {showToggle && (
+        <DamageTypeToggle
+          setShowRanged={setShowRanged}
+          showRanged={showRanged}
+        />
+      )}
       <div css={{ display: 'grid', gridTemplateColumns: '1fr 1fr' }}>
         <div css={damageHeaderStyle}>{t('NON_CRIT')}</div>
         {weaponStats.baseCritChance ? (

--- a/client/graphql/fragments/__generated__/customSet.ts
+++ b/client/graphql/fragments/__generated__/customSet.ts
@@ -55,6 +55,7 @@ export interface customSet_equippedItems_item_itemType {
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: customSet_equippedItems_item_itemType_eligibleItemSlots[];
 }
 

--- a/client/graphql/fragments/__generated__/item.ts
+++ b/client/graphql/fragments/__generated__/item.ts
@@ -48,6 +48,7 @@ export interface item_itemType {
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: item_itemType_eligibleItemSlots[];
 }
 

--- a/client/graphql/fragments/item.graphql
+++ b/client/graphql/fragments/item.graphql
@@ -29,6 +29,7 @@ fragment item on Item {
   itemType {
     id
     name
+    enName
     eligibleItemSlots {
       id
       order

--- a/client/graphql/mutations/__generated__/copyCustomSet.ts
+++ b/client/graphql/mutations/__generated__/copyCustomSet.ts
@@ -12,6 +12,7 @@ import { Stat, WeaponEffectType, WeaponElementMage } from "./../../../__generate
 export interface copyCustomSet_copyCustomSet_customSet_equippedItems_slot {
   __typename: "ItemSlot";
   id: any;
+  name: string;
   order: number;
 }
 
@@ -54,6 +55,7 @@ export interface copyCustomSet_copyCustomSet_customSet_equippedItems_item_itemTy
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: copyCustomSet_copyCustomSet_customSet_equippedItems_item_itemType_eligibleItemSlots[];
 }
 

--- a/client/graphql/mutations/__generated__/createCustomSet.ts
+++ b/client/graphql/mutations/__generated__/createCustomSet.ts
@@ -55,6 +55,7 @@ export interface createCustomSet_createCustomSet_customSet_equippedItems_item_it
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: createCustomSet_createCustomSet_customSet_equippedItems_item_itemType_eligibleItemSlots[];
 }
 

--- a/client/graphql/mutations/__generated__/equipItems.ts
+++ b/client/graphql/mutations/__generated__/equipItems.ts
@@ -12,6 +12,7 @@ import { Stat, WeaponEffectType, WeaponElementMage } from "./../../../__generate
 export interface equipItems_equipMultipleItems_customSet_equippedItems_slot {
   __typename: "ItemSlot";
   id: any;
+  name: string;
   order: number;
 }
 
@@ -54,6 +55,7 @@ export interface equipItems_equipMultipleItems_customSet_equippedItems_item_item
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: equipItems_equipMultipleItems_customSet_equippedItems_item_itemType_eligibleItemSlots[];
 }
 

--- a/client/graphql/mutations/__generated__/equipSet.ts
+++ b/client/graphql/mutations/__generated__/equipSet.ts
@@ -55,6 +55,7 @@ export interface equipSet_equipSet_customSet_equippedItems_item_itemType {
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: equipSet_equipSet_customSet_equippedItems_item_itemType_eligibleItemSlots[];
 }
 

--- a/client/graphql/mutations/__generated__/restartCustomSet.ts
+++ b/client/graphql/mutations/__generated__/restartCustomSet.ts
@@ -12,6 +12,7 @@ import { Stat, WeaponEffectType, WeaponElementMage } from "./../../../__generate
 export interface restartCustomSet_restartCustomSet_customSet_equippedItems_slot {
   __typename: "ItemSlot";
   id: any;
+  name: string;
   order: number;
 }
 
@@ -54,6 +55,7 @@ export interface restartCustomSet_restartCustomSet_customSet_equippedItems_item_
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: restartCustomSet_restartCustomSet_customSet_equippedItems_item_itemType_eligibleItemSlots[];
 }
 

--- a/client/graphql/mutations/__generated__/updateCustomSetItem.ts
+++ b/client/graphql/mutations/__generated__/updateCustomSetItem.ts
@@ -55,6 +55,7 @@ export interface updateCustomSetItem_updateCustomSetItem_customSet_equippedItems
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: updateCustomSetItem_updateCustomSetItem_customSet_equippedItems_item_itemType_eligibleItemSlots[];
 }
 

--- a/client/graphql/queries/__generated__/customSet.ts
+++ b/client/graphql/queries/__generated__/customSet.ts
@@ -55,6 +55,7 @@ export interface customSet_customSetById_equippedItems_item_itemType {
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: customSet_customSetById_equippedItems_item_itemType_eligibleItemSlots[];
 }
 

--- a/client/graphql/queries/__generated__/items.ts
+++ b/client/graphql/queries/__generated__/items.ts
@@ -48,6 +48,7 @@ export interface items_items_edges_node_itemType {
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: items_items_edges_node_itemType_eligibleItemSlots[];
 }
 

--- a/client/graphql/queries/__generated__/set.ts
+++ b/client/graphql/queries/__generated__/set.ts
@@ -57,6 +57,7 @@ export interface set_setById_items_itemType {
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: set_setById_items_itemType_eligibleItemSlots[];
 }
 

--- a/client/graphql/queries/__generated__/sets.ts
+++ b/client/graphql/queries/__generated__/sets.ts
@@ -57,6 +57,7 @@ export interface sets_sets_edges_node_items_itemType {
   __typename: "ItemType";
   id: any;
   name: string;
+  enName: string;
   eligibleItemSlots: sets_sets_edges_node_items_itemType_eligibleItemSlots[];
 }
 

--- a/server/app/schema.py
+++ b/server/app/schema.py
@@ -141,12 +141,22 @@ class ItemSlot(SQLAlchemyObjectType):
 class ItemType(SQLAlchemyObjectType):
     eligible_item_slots = graphene.NonNull(graphene.List(graphene.NonNull(ItemSlot)))
     name = graphene.String(required=True)
+    en_name = graphene.String(required=True)
 
     def resolve_name(self, info):
         locale = str(get_locale())
         query = db.session.query(ModelItemTypeTranslation)
         return (
             query.filter(ModelItemTypeTranslation.locale == locale)
+            .filter(ModelItemTypeTranslation.item_type_id == self.uuid)
+            .one()
+            .name
+        )
+
+    def resolve_en_name(self, info):
+        query = db.session.query(ModelItemTypeTranslation)
+        return (
+            query.filter(ModelItemTypeTranslation.locale == "en")
             .filter(ModelItemTypeTranslation.item_type_id == self.uuid)
             .one()
             .name


### PR DESCRIPTION
Fixes: #99 

- Expose "enName" on ItemType to be able to find out what kind of weapon is equipped
- Use itemType.enName to find out if user has an axe equipped, in which case, show the toggle for melee vs ranged damage
- Fixed a bug where spells that have minimum range were being set to melee damage without displaying a toggle

![chrome_jrBBefrQMx](https://user-images.githubusercontent.com/27422540/80784620-8ab58900-8b32-11ea-93ce-e4679968aedb.png)
![chrome_fhoBkPW1vS](https://user-images.githubusercontent.com/27422540/80784622-8be6b600-8b32-11ea-8465-d4a7831e23aa.png)
