### PR TITLE
Add dependency to useCallback when deleting item

### DIFF
--- a/client/common/utils.tsx
+++ b/client/common/utils.tsx
@@ -553,7 +553,7 @@ export const useDeleteItemMutation = (
     const ok = await checkAuthentication(client, t, customSet);
     if (!ok) return null;
     return mutate();
-  }, [mutate]);
+  }, [mutate, customSet]);
   return onDelete;
 };
 


### PR DESCRIPTION
Fixes: #106 

When the customSet was changing, the callback that calls checkAuthentication was not changing, so it was still passing the original build in.