### PR TITLE
Split migration into new best element steal only

### DIFF
--- a/server/app/migrations/versions/3c596c660380_add_best_element_steal.py
+++ b/server/app/migrations/versions/3c596c660380_add_best_element_steal.py
@@ -1,8 +1,8 @@
 """empty message
 
-Revision ID: 0f157bb2d68b
-Revises: f175244278d9
-Create Date: 2025-08-29 19:23:34.351988
+Revision ID: 3c596c660380
+Revises: 0f157bb2d68b
+Create Date: 2025-09-23 22:11:20
 
 """
 
@@ -11,12 +11,12 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = "0f157bb2d68b"
-down_revision = "f175244278d9"
+revision = "3c596c660380"
+down_revision = "0f157bb2d68b"
 branch_labels = None
 depends_on = None
 
-new_enums = ["BEST_ELEMENT_DAMAGE", "PUSHBACK_DAMAGE", "ATTRACT_CELLS", "STEALS_MP"]
+new_enums = ["BEST_ELEMENT_STEAL"]
 
 
 def upgrade():


### PR DESCRIPTION
### TL;DR

Moved `BEST_ELEMENT_STEAL` enum value to a separate migration file.

### What changed?

- Removed `BEST_ELEMENT_STEAL` from the list of new enum values in the existing migration file `0f157bb2d68b_.py`
- Created a new migration file `3c596c660380_add_best_element_steal.py` that specifically adds the `BEST_ELEMENT_STEAL` enum value
- The new migration depends on the previous one, ensuring proper sequencing

### How to test?

1. Run database migrations to verify they apply correctly
2. Check that the `weapon_effect_type` enum in the database contains all expected values including `BEST_ELEMENT_STEAL`
3. Verify that downgrade functionality works correctly by testing the rollback of these migrations

### Why make this change?

Separating the `BEST_ELEMENT_STEAL` enum into its own migration provides better organization and allows for more granular control over database schema changes. This approach makes it easier to track specific enum additions and simplifies potential rollbacks if needed.