### PR TITLE
Improve build page load stability

### DIFF
--- a/client/components/common/BuildPage.tsx
+++ b/client/components/common/BuildPage.tsx
@@ -2,12 +2,11 @@
 
 import { useMemo, useContext } from 'react';
 
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 
 import DesktopSetBuilder from 'components/desktop/SetBuilder';
 import MobileSetBuilder from 'components/mobile/SetBuilder';
-import { mediaStyles, Media } from 'components/common/Media';
+import { Media } from 'components/common/Media';
 
 import { CustomSetHead } from 'common/wrappers';
 import ClassicSetBuilder from 'components/desktop/ClassicSetBuilder';
@@ -35,13 +34,6 @@ const BuildPage = () => {
   return (
     <ClassicContext.Provider value={contextValue}>
       <div className="App" css={{ height: '100%' }} suppressHydrationWarning>
-        <Head>
-          <style
-            type="text/css"
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: mediaStyles }}
-          />
-        </Head>
         <CustomSetHead customSet={customSet} />
 
         <Media lessThan="xs">

--- a/client/components/common/EquipPage.tsx
+++ b/client/components/common/EquipPage.tsx
@@ -1,8 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { useCallback, useMemo } from 'react';
-import Head from 'next/head';
-import { mediaStyles, Media } from 'components/common/Media';
+import { Media } from 'components/common/Media';
 import Selector from 'components/common/Selector';
 import { useRouter } from 'next/router';
 import { useQuery } from '@apollo/client';
@@ -60,13 +59,6 @@ const EquipPage = ({ customSetId, itemSlotId }: Props) => {
     <>
       <Media lessThan="xs">
         <MobileLayout>
-          <Head>
-            <style
-              type="text/css"
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: mediaStyles }}
-            />
-          </Head>
           {customSet ? (
             <CustomSetHead customSet={customSet} />
           ) : (
@@ -84,13 +76,6 @@ const EquipPage = ({ customSetId, itemSlotId }: Props) => {
       <Media greaterThanOrEqual="xs">
         <ClassicContext.Provider value={contextValue}>
           <DesktopLayout showSwitch>
-            <Head>
-              <style
-                type="text/css"
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={{ __html: mediaStyles }}
-              />
-            </Head>
             <CustomSetHead customSet={customSet} />
             <Selector
               customSet={customSet}

--- a/client/components/common/SelectorFilters.tsx
+++ b/client/components/common/SelectorFilters.tsx
@@ -313,7 +313,19 @@ const SelectorFilters = ({
           <ClassNames>
             {({ css }) => (
               // https://github.com/ant-design/ant-design/issues/30396
-              <NoSSR>
+              <NoSSR
+                onSSR={
+                  <div
+                    css={{
+                      flex: '1 1 0%',
+                      height: 42,
+                      [mq[1]]: {
+                        height: isClassic ? 40 : 32,
+                      },
+                    }}
+                  />
+                }
+              >
                 <Select
                   getPopupContainer={(node: HTMLElement) => {
                     if (node.parentElement) {

--- a/client/components/common/SetHeaderMetadata.tsx
+++ b/client/components/common/SetHeaderMetadata.tsx
@@ -31,7 +31,9 @@ function SetHeaderMetadata({
     <div css={{ display: 'flex' }}>
       <div css={{ fontWeight: 500 }}>{t(translationLabelId)}</div>
       <div css={{ marginLeft: 8 }}>
-        <NoSSR>{node}</NoSSR>
+        <NoSSR onSSR={<span css={{ display: 'inline-block', minWidth: 132 }} />}>
+          {node}
+        </NoSSR>
       </div>
     </div>
   );

--- a/client/components/desktop/Layout.tsx
+++ b/client/components/desktop/Layout.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 
 import { useState, useCallback, useRef, useEffect } from 'react';
+import dynamic from 'next/dynamic';
 
 import { Global, useTheme } from '@emotion/react';
 import {
@@ -47,18 +48,32 @@ import {
   changeLocaleVariables,
 } from 'graphql/mutations/__generated__/changeLocale';
 import changeLocaleMutation from 'graphql/mutations/changeLocale.graphql';
-import ChangePasswordModal from 'components/common/ChangePasswordModal';
 import { LIGHT_THEME_NAME } from 'common/themes';
 import Tooltip from 'components/common/Tooltip';
 import { switchStyle } from 'common/mixins';
 import { ClassicContext, getImageUrl } from 'common/utils';
 import { DownOutlined } from '@ant-design/icons';
 import { Media } from 'components/common/Media';
-import DefaultBuildSettingsModal from 'components/common/DefaultBuildSettingsModal';
-import BuildList from '../common/BuildList';
-import SignUpModal from '../common/SignUpModal';
-import LoginModal from '../common/LoginModal';
-import KeyboardShortcutsModal from './KeyboardShortcutsModal';
+
+const BuildList = dynamic(() => import('../common/BuildList'), { ssr: false });
+const SignUpModal = dynamic(() => import('../common/SignUpModal'), {
+  ssr: false,
+});
+const LoginModal = dynamic(() => import('../common/LoginModal'), {
+  ssr: false,
+});
+const ChangePasswordModal = dynamic(
+  () => import('components/common/ChangePasswordModal'),
+  { ssr: false },
+);
+const DefaultBuildSettingsModal = dynamic(
+  () => import('components/common/DefaultBuildSettingsModal'),
+  { ssr: false },
+);
+const KeyboardShortcutsModal = dynamic(
+  () => import('./KeyboardShortcutsModal'),
+  { ssr: false },
+);
 
 interface LayoutProps {
   children: ReactNode;
@@ -337,6 +352,8 @@ function Layout({ children, showSwitch }: LayoutProps) {
                       ? 'logo/DL-Full_Light.svg'
                       : 'logo/DL-Full_Dark.svg',
                   )}
+                  width={120}
+                  height={36}
                   css={{ width: 120 }}
                   alt="DofusLab"
                 />
@@ -534,28 +551,38 @@ function Layout({ children, showSwitch }: LayoutProps) {
         >
           {children}
         </AntdLayout.Content>
-        <LoginModal
-          open={showLoginModal}
-          onClose={closeLoginModal}
-          openSignUpModal={openSignUpModal}
-        />
-        <SignUpModal
-          open={showSignUpModal}
-          onClose={closeSignUpModal}
-          openLoginModal={openLoginModal}
-        />
-        <ChangePasswordModal
-          open={showPasswordModal}
-          onClose={closePasswordModal}
-        />
-        <DefaultBuildSettingsModal
-          open={showBuildSettings}
-          onClose={closeBuildSettings}
-        />
-        <KeyboardShortcutsModal
-          open={showKeyboardShortcuts}
-          onClose={closeKeyboardShortcuts}
-        />
+        {showLoginModal && (
+          <LoginModal
+            open={showLoginModal}
+            onClose={closeLoginModal}
+            openSignUpModal={openSignUpModal}
+          />
+        )}
+        {showSignUpModal && (
+          <SignUpModal
+            open={showSignUpModal}
+            onClose={closeSignUpModal}
+            openLoginModal={openLoginModal}
+          />
+        )}
+        {showPasswordModal && (
+          <ChangePasswordModal
+            open={showPasswordModal}
+            onClose={closePasswordModal}
+          />
+        )}
+        {showBuildSettings && (
+          <DefaultBuildSettingsModal
+            open={showBuildSettings}
+            onClose={closeBuildSettings}
+          />
+        )}
+        {showKeyboardShortcuts && (
+          <KeyboardShortcutsModal
+            open={showKeyboardShortcuts}
+            onClose={closeKeyboardShortcuts}
+          />
+        )}
       </AntdLayout>
     </AntdRegistry>
   );

--- a/client/components/mobile/EquippedItemView.tsx
+++ b/client/components/mobile/EquippedItemView.tsx
@@ -13,8 +13,6 @@ import EquippedItemCard from 'components/mobile/EquippedItemCard';
 import ErrorPage from 'pages/_error';
 import MageModal from 'components/common/MageModal';
 import SetModal from 'components/common/SetModal';
-import { mediaStyles } from 'components/common/Media';
-import Head from 'next/head';
 import { getErrors, getStatsFromCustomSet } from 'common/utils';
 import { BuildError } from 'common/types';
 import { CustomSetHead } from 'common/wrappers';
@@ -81,13 +79,6 @@ const EquippedItemView = () => {
 
   return (
     <Layout>
-      <Head>
-        <style
-          type="text/css"
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: mediaStyles }}
-        />
-      </Head>
       <CustomSetHead customSet={customSet} />
       <EquippedItemCard
         equippedItem={equippedItem}

--- a/client/components/mobile/Layout.tsx
+++ b/client/components/mobile/Layout.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 
 import { useState, useCallback, useMemo } from 'react';
+import dynamic from 'next/dynamic';
 import { Global, useTheme } from '@emotion/react';
 import { Layout as AntdLayout, Button, Menu, Drawer } from 'antd';
 import type { MenuProps } from 'antd';
@@ -38,7 +39,6 @@ import {
   changeLocaleVariables,
 } from 'graphql/mutations/__generated__/changeLocale';
 import changeLocaleMutation from 'graphql/mutations/changeLocale.graphql';
-import ChangePasswordModal from 'components/common/ChangePasswordModal';
 import { LIGHT_THEME_NAME } from 'common/themes';
 import {
   DISCORD_SERVER_LINK,
@@ -46,9 +46,21 @@ import {
   BUY_ME_COFFEE_LINK,
 } from 'common/constants';
 import { getImageUrl } from 'common/utils';
-import DefaultBuildSettingsModal from 'components/common/DefaultBuildSettingsModal';
-import SignUpModal from '../common/SignUpModal';
-import LoginModal from '../common/LoginModal';
+
+const SignUpModal = dynamic(() => import('../common/SignUpModal'), {
+  ssr: false,
+});
+const LoginModal = dynamic(() => import('../common/LoginModal'), {
+  ssr: false,
+});
+const ChangePasswordModal = dynamic(
+  () => import('components/common/ChangePasswordModal'),
+  { ssr: false },
+);
+const DefaultBuildSettingsModal = dynamic(
+  () => import('components/common/DefaultBuildSettingsModal'),
+  { ssr: false },
+);
 
 interface LayoutProps {
   children: ReactNode;
@@ -396,6 +408,8 @@ function Layout({ children }: LayoutProps) {
                     ? 'logo/DL-Full_Light.svg'
                     : 'logo/DL-Full_Dark.svg',
                 )}
+                width={120}
+                height={36}
                 css={{ width: 120 }}
                 alt="DofusLab"
               />
@@ -470,24 +484,32 @@ function Layout({ children }: LayoutProps) {
         >
           {children}
         </AntdLayout.Content>
-        <LoginModal
-          open={showLoginModal}
-          onClose={closeLoginModal}
-          openSignUpModal={openSignUpModal}
-        />
-        <SignUpModal
-          open={showSignUpModal}
-          onClose={closeSignUpModal}
-          openLoginModal={openLoginModal}
-        />
-        <ChangePasswordModal
-          open={showPasswordModal}
-          onClose={closePasswordModal}
-        />
-        <DefaultBuildSettingsModal
-          open={showBuildSettings}
-          onClose={closeBuildSettings}
-        />
+        {showLoginModal && (
+          <LoginModal
+            open={showLoginModal}
+            onClose={closeLoginModal}
+            openSignUpModal={openSignUpModal}
+          />
+        )}
+        {showSignUpModal && (
+          <SignUpModal
+            open={showSignUpModal}
+            onClose={closeSignUpModal}
+            openLoginModal={openLoginModal}
+          />
+        )}
+        {showPasswordModal && (
+          <ChangePasswordModal
+            open={showPasswordModal}
+            onClose={closePasswordModal}
+          />
+        )}
+        {showBuildSettings && (
+          <DefaultBuildSettingsModal
+            open={showBuildSettings}
+            onClose={closeBuildSettings}
+          />
+        )}
       </AntdLayout>
     </AntdRegistry>
   );

--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -9,12 +9,18 @@ import Document, {
 import { extractStyle, createCache, StyleProvider } from '@ant-design/cssinjs';
 
 import { GA_TRACKING_ID } from '../gtag';
+import { mediaStyles } from '../components/common/Media';
 
 const DofusLabDocument = ({ __NEXT_DATA__ }: DocumentProps) => {
   return (
     // eslint-disable-next-line no-underscore-dangle
     <Html lang={__NEXT_DATA__.props.initialLanguage}>
       <Head>
+        <style
+          type="text/css"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: mediaStyles }}
+        />
         <meta property="og:type" content="website" />
         <meta property="twitter:card" content="summary_large_image" />
         <link

--- a/client/pages/my-builds.tsx
+++ b/client/pages/my-builds.tsx
@@ -5,7 +5,6 @@ import Router from 'next/router';
 
 import { currentUser } from 'graphql/queries/__generated__/currentUser';
 import Layout from 'components/mobile/Layout';
-import { mediaStyles } from 'components/common/Media';
 import Head from 'next/head';
 import CurrentUserQuery from 'graphql/queries/currentUser.graphql';
 import BuildList from 'components/common/BuildList';
@@ -38,11 +37,6 @@ const MyBuildsPage: NextPage = () => {
   return (
     <Layout>
       <Head>
-        <style
-          type="text/css"
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: mediaStyles }}
-        />
         <title>{getTitle(t('MY_BUILDS'))}</title>
       </Head>
       {data?.currentUser && (

--- a/client/pages/reset-password.tsx
+++ b/client/pages/reset-password.tsx
@@ -5,7 +5,6 @@ import { GetStaticProps, NextPage } from 'next';
 import { useQuery, useMutation } from '@apollo/client';
 
 import { currentUser } from 'graphql/queries/__generated__/currentUser';
-import { mediaStyles } from 'components/common/Media';
 import Head from 'next/head';
 import currentUserQuery from 'graphql/queries/currentUser.graphql';
 import { useRouter } from 'next/router';
@@ -80,11 +79,6 @@ const RequestPasswordResetPage: NextPage = () => {
   return (
     <CommonLayout showSwitch={false}>
       <Head>
-        <style
-          type="text/css"
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: mediaStyles }}
-        />
         <title>{getTitle(t('CHANGE_PASSWORD'))}</title>
       </Head>
       <div

--- a/client/pages/verify-email.tsx
+++ b/client/pages/verify-email.tsx
@@ -5,7 +5,6 @@ import { GetStaticProps, NextPage } from 'next';
 import { useQuery, useMutation } from '@apollo/client';
 
 import { currentUser } from 'graphql/queries/__generated__/currentUser';
-import { mediaStyles } from 'components/common/Media';
 import Head from 'next/head';
 import currentUserQuery from 'graphql/queries/currentUser.graphql';
 import { useRouter } from 'next/router';
@@ -48,11 +47,6 @@ const VerifyEmailPage: NextPage = () => {
   return (
     <CommonLayout showSwitch={false}>
       <Head>
-        <style
-          type="text/css"
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: mediaStyles }}
-        />
         <title>DofusLab</title>
       </Head>
       <div

--- a/client/pages/view/[customSetId].tsx
+++ b/client/pages/view/[customSetId].tsx
@@ -23,8 +23,7 @@ import {
 } from 'graphql/queries/__generated__/customSet';
 import CustomSetQuery from 'graphql/queries/customSet.graphql';
 import { CustomSetContext, EditableContext } from 'common/utils';
-import Head from 'next/head';
-import { Media, mediaStyles } from 'components/common/Media';
+import { Media } from 'components/common/Media';
 import MobileSetBuilder from 'components/mobile/SetBuilder';
 import ClassicSetBuilder from 'components/desktop/ClassicSetBuilder';
 import { CustomSetHead } from 'common/wrappers';
@@ -51,13 +50,6 @@ const ViewPage: NextPage = () => {
 
   return (
     <div className="App" css={{ height: '100%' }}>
-      <Head>
-        <style
-          type="text/css"
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: mediaStyles }}
-        />
-      </Head>
       <CustomSetHead customSet={customSet} />
       <EditableContext.Provider value={false}>
         <Media lessThan="xs">


### PR DESCRIPTION
## Summary

- Move Fresnel media CSS into `_document` so responsive branch visibility is available before the app body renders.
- Reserve SSR space for no-SSR controls/date metadata that previously appeared only after hydration.
- Add intrinsic header logo dimensions to reduce layout movement.
- Lazy-load closed modal/drawer-only layout components to reduce initial route JS.

## Impact

This keeps the three distinct build experiences intact while reducing avoidable layout instability and initial JS for routes that do not need modal-heavy UI immediately.

Measured from `next build` on this branch:

```text
/                      ~609 kB First Load JS
/equip/set             ~558 kB
/verify-email          ~457 kB
/view/[customSetId]    ~586 kB
```

Compared with the pre-change local build, the main routes dropped roughly 49-127 kB of first-load JS depending on route.

## Validation

- `yarn type-check`
- `NEXT_PUBLIC_GRAPHQL_URI=https://dofuslab.io/api/graphql yarn build`

Notes: build still reports the existing Next config warning for `turbopack.env`, DefinePlugin env warnings, and large page-data warnings for `/` and `/equip/set`.