### PR TITLE
Expose synchronous generated build discovery

### DIFF
--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -163,6 +163,7 @@ from app.loaders import (
     SpellDamageIncreaseLoader,
     EligibleItemSlotLoader,
     SpellDescriptionLoader,
+    GenerationRequestLoader,
 )
 
 
@@ -181,6 +182,7 @@ def construct_dataloaders():
         "spell_buff_loader": SpellBuffLoader(),
         "item_buff_loader": ItemBuffLoader(),
         "custom_set_tag_association_loader": CustomSetTagAssociationLoader(),
+        "generation_request_loader": GenerationRequestLoader(),
         "custom_set_tag_translation_loader": CustomSetTagTranslationLoader(),
         "item_slot_translation_loader": ItemSlotTranslationLoader(),
         "item_type_translation_loader": ItemTypeTranslationLoader(),

--- a/server/app/build_discovery_graphql.py
+++ b/server/app/build_discovery_graphql.py
@@ -1,0 +1,468 @@
+from functools import lru_cache
+
+import graphene
+from ddtrace import tracer
+from graphql import GraphQLError
+
+from app import limiter
+from app.build_discovery_promotion import sign_build_discovery_candidate
+from app.build_discovery_service import (
+    BuildDiscoverySolveLockTimeout,
+    build_discovery_app_cache_key,
+    build_discovery_cached_response,
+)
+from oneoff.build_discovery_core import (
+    BuildDiscoveryQuery,
+    DEFAULT_MAX_SHARED_ITEMS,
+    MAX_AP,
+    MAX_MP,
+    MAX_RANGE,
+    dataset_version,
+    load_build_discovery_index,
+    query_summary,
+)
+from oneoff.generate_build_discovery_index import (
+    BuildDiscoveryIndexValidationError,
+    validate_build_discovery_index,
+)
+
+
+MAX_RESULT_LIMIT = 5
+MAX_ITEM_CONTROLS = 50
+MAX_SHARED_ITEMS = 16
+
+
+def bounded_int_arg(name, value, minimum, maximum):
+    if value < minimum or value > maximum:
+        raise GraphQLError(f"{name} must be between {minimum} and {maximum}.")
+    return value
+
+
+def build_discovery_query_from_input(input_value):
+    locked_item_ids = tuple(input_value.locked_item_ids)
+    avoided_item_ids = tuple(input_value.avoided_item_ids)
+    if len(locked_item_ids) > MAX_ITEM_CONTROLS:
+        raise GraphQLError(
+            f"lockedItemIds cannot contain more than {MAX_ITEM_CONTROLS} items."
+        )
+    if len(avoided_item_ids) > MAX_ITEM_CONTROLS:
+        raise GraphQLError(
+            f"avoidedItemIds cannot contain more than {MAX_ITEM_CONTROLS} items."
+        )
+    return BuildDiscoveryQuery(
+        class_name=input_value.class_name,
+        level=input_value.level,
+        elements=(input_value.element,),
+        mode="pvm",
+        ap_target=input_value.ap_target,
+        mp_target=input_value.mp_target,
+        range_target=input_value.range_target,
+        damage_survivability_preset=input_value.damage_survivability_preset,
+        budget_tier=input_value.budget_tier,
+        exo_policy=input_value.exo_policy,
+        weapon_policy=input_value.weapon_policy,
+        locked_item_ids=locked_item_ids,
+        avoided_item_ids=avoided_item_ids,
+        limit=bounded_int_arg(
+            "resultLimit",
+            input_value.result_limit,
+            1,
+            MAX_RESULT_LIMIT,
+        ),
+        max_shared_items=bounded_int_arg(
+            "maxSharedItems",
+            input_value.max_shared_items,
+            0,
+            MAX_SHARED_ITEMS,
+        ),
+    )
+
+
+@lru_cache(maxsize=4)
+def validate_build_discovery_index_version(dataset_version):
+    index = load_build_discovery_index()
+    if index is None:
+        raise BuildDiscoveryIndexValidationError("index file is absent")
+    validate_build_discovery_index(index)
+
+
+def require_build_discovery_index():
+    try:
+        validate_build_discovery_index_version(dataset_version())
+    except (BuildDiscoveryIndexValidationError, OSError, ValueError) as exc:
+        raise GraphQLError(f"Build Discovery index is not production-ready: {exc}")
+
+
+def product_build_discovery_response(query, response):
+    builds = []
+    build_field_names = (
+        "weightedStatScore",
+        "utilityStatScore",
+        "genericDamageScore",
+        "rawRotationDamageScore",
+        "spellDamageScore",
+        "profileBaselineDamageScore",
+        "profileRelativeDamage",
+        "weaponDamageScore",
+        "survivabilityScore",
+        "negativeResistancePenalty",
+        "weakestElementEhp",
+        "apStrategy",
+    )
+    for rank, build in enumerate(response.get("builds") or (), start=1):
+        normalized = dict(build)
+        for camel_name in build_field_names:
+            snake_name = "".join(
+                f"_{character.lower()}" if character.isupper() else character
+                for character in camel_name
+            )
+            normalized[snake_name] = build.get(camel_name)
+        normalized["promotion_token"] = sign_build_discovery_candidate(
+            query, response, build, rank=rank
+        )
+        builds.append(normalized)
+
+    query_payload = query_summary(query)
+    diagnostics_payload = response.get("diagnostics") or {}
+    diagnostic_field_names = (
+        "elapsedMs",
+        "cacheHit",
+        "appCacheHit",
+        "cacheStatus",
+        "solveLockAcquired",
+        "lockWaitMs",
+        "solverStatus",
+        "workers",
+        "itemCount",
+        "candidateCount",
+        "maxSharedItems",
+        "maxSharedItemsEnforced",
+    )
+    diagnostics = {
+        "result_count": diagnostics_payload.get("resultCount", len(builds)),
+        "solver": diagnostics_payload.get("solver"),
+        "timings": diagnostics_payload.get("timings") or {},
+    }
+    for camel_name in diagnostic_field_names:
+        snake_name = "".join(
+            f"_{character.lower()}" if character.isupper() else character
+            for character in camel_name
+        )
+        diagnostics[snake_name] = diagnostics_payload.get(camel_name)
+
+    target_semantics = response.get("targetSemantics") or {}
+    no_build_reason = response.get("noBuildReason")
+    return {
+        "status": response.get("status", "complete"),
+        "dataset_version": response.get("datasetVersion") or dataset_version(),
+        "solver_version": response.get("solverVersion"),
+        "cache_key": response.get("cacheKey") or build_discovery_app_cache_key(query),
+        "query": {
+            "class_name": query_payload["className"],
+            "level": query_payload["level"],
+            "elements": query_payload["elements"],
+            "mode": query_payload["mode"],
+            "ap_target": query_payload["apTarget"],
+            "mp_target": query_payload["mpTarget"],
+            "range_target": query_payload["rangeTarget"],
+            "damage_survivability_preset": query_payload["damageSurvivabilityPreset"],
+            "budget_tier": query_payload["budgetTier"],
+            "exo_policy": query_payload["exoPolicy"],
+            "weapon_policy": query_payload["weaponPolicy"],
+            "locked_item_ids": query_payload["lockedItemIds"],
+            "avoided_item_ids": query_payload["avoidedItemIds"],
+            "result_limit": query.limit,
+            "max_shared_items": query.max_shared_items,
+        },
+        "target_semantics": {
+            "type": target_semantics.get("type", "minimum_with_hard_caps"),
+            "targets": target_semantics.get("targets")
+            or {
+                "AP": "minimum",
+                "MP": "minimum",
+                "Range": "minimum_when_requested",
+            },
+            "caps": target_semantics.get("caps")
+            or {"AP": MAX_AP, "MP": MAX_MP, "Range": MAX_RANGE},
+            "surplus_scoring": target_semantics.get(
+                "surplusScoring", "light_reward_with_cap"
+            ),
+        },
+        "warnings": response.get("warnings") or [],
+        "no_build_reason": (
+            {
+                "code": no_build_reason.get("code"),
+                "unavailable_item_ids": no_build_reason.get("unavailableItemIds") or [],
+                "wrong_slot_item_ids": no_build_reason.get("wrongSlotItemIds") or [],
+            }
+            if no_build_reason
+            else None
+        ),
+        "diagnostics": diagnostics,
+        "cache": response.get("cache")
+        or {
+            "status": "miss",
+            "storage": "app_cache",
+        },
+        "builds": builds,
+    }
+
+
+class BuildDiscoveryInput(graphene.InputObjectType):
+    class_name = graphene.String(required=True)
+    level = graphene.Int(required=True)
+    element = graphene.String(required=True)
+    ap_target = graphene.Int(required=True)
+    mp_target = graphene.Int(required=True)
+    range_target = graphene.Int()
+    damage_survivability_preset = graphene.Int(required=True)
+    budget_tier = graphene.Int(required=True)
+    exo_policy = graphene.String(required=True)
+    weapon_policy = graphene.String(required=True)
+    locked_item_ids = graphene.NonNull(graphene.List(graphene.NonNull(graphene.String)))
+    avoided_item_ids = graphene.NonNull(
+        graphene.List(graphene.NonNull(graphene.String))
+    )
+    result_limit = graphene.Int(required=True)
+    max_shared_items = graphene.Int(default_value=DEFAULT_MAX_SHARED_ITEMS)
+
+
+class BuildDiscoveryStatus(graphene.Enum):
+    COMPLETE = "complete"
+    NO_VALID_BUILD = "no_valid_build"
+
+
+class BuildDiscoveryQueryResult(graphene.ObjectType):
+    class_name = graphene.String(required=True)
+    level = graphene.Int(required=True)
+    elements = graphene.NonNull(graphene.List(graphene.NonNull(graphene.String)))
+    mode = graphene.String(required=True)
+    ap_target = graphene.Int(required=True)
+    mp_target = graphene.Int(required=True)
+    range_target = graphene.Int()
+    damage_survivability_preset = graphene.Int(required=True)
+    budget_tier = graphene.Int(required=True)
+    exo_policy = graphene.String(required=True)
+    weapon_policy = graphene.String(required=True)
+    locked_item_ids = graphene.NonNull(graphene.List(graphene.NonNull(graphene.String)))
+    avoided_item_ids = graphene.NonNull(
+        graphene.List(graphene.NonNull(graphene.String))
+    )
+    result_limit = graphene.Int(required=True)
+    max_shared_items = graphene.Int()
+
+
+class BuildDiscoveryNamedNumber(graphene.ObjectType):
+    name = graphene.String(required=True)
+    value = graphene.Float(required=True)
+
+
+class BuildDiscoverySet(graphene.ObjectType):
+    name = graphene.String(required=True)
+    item_count = graphene.Int(required=True)
+
+
+class BuildDiscoveryItem(graphene.ObjectType):
+    slot = graphene.String(required=True)
+    id = graphene.String(required=True)
+    internal_id = graphene.String()
+    name = graphene.String(required=True)
+    type = graphene.String(required=True)
+    level = graphene.Int()
+    set = graphene.String()
+
+
+class BuildDiscoveryExo(graphene.ObjectType):
+    stat = graphene.String(required=True)
+    item_id = graphene.String(required=True)
+    slot = graphene.String()
+
+
+class BuildDiscoveryBuild(graphene.ObjectType):
+    promotion_token = graphene.String(required=True)
+    score = graphene.Float(required=True)
+    weighted_stat_score = graphene.Float()
+    utility_stat_score = graphene.Float()
+    generic_damage_score = graphene.Float()
+    raw_rotation_damage_score = graphene.Float()
+    spell_damage_score = graphene.Float()
+    profile_baseline_damage_score = graphene.Float()
+    profile_relative_damage = graphene.Float()
+    weapon_damage_score = graphene.Float()
+    survivability_score = graphene.Float()
+    negative_resistance_penalty = graphene.Float()
+    weakest_element_ehp = graphene.Float()
+    ap_strategy = graphene.String()
+    condition_failures = graphene.List(graphene.NonNull(graphene.String), required=True)
+    base_allocation = graphene.List(
+        graphene.NonNull(BuildDiscoveryNamedNumber), required=True
+    )
+    totals = graphene.List(graphene.NonNull(BuildDiscoveryNamedNumber), required=True)
+    sets = graphene.List(graphene.NonNull(BuildDiscoverySet), required=True)
+    exos = graphene.List(graphene.NonNull(BuildDiscoveryExo), required=True)
+    items = graphene.List(graphene.NonNull(BuildDiscoveryItem), required=True)
+
+    def resolve_condition_failures(self, info):
+        return self.get("conditionFailures") or []
+
+    def resolve_base_allocation(self, info):
+        return [
+            {"name": name, "value": value}
+            for name, value in (self.get("baseAllocation") or {}).items()
+        ]
+
+    def resolve_totals(self, info):
+        return [
+            {"name": name, "value": value}
+            for name, value in (self.get("totals") or {}).items()
+        ]
+
+    def resolve_sets(self, info):
+        return [
+            {"name": name, "item_count": item_count}
+            for name, item_count in (self.get("sets") or {}).items()
+        ]
+
+    def resolve_exos(self, info):
+        return [
+            {
+                "stat": stat,
+                "item_id": exo.get("itemId"),
+                "slot": exo.get("slot"),
+            }
+            for stat, exo in (self.get("exos") or {}).items()
+        ]
+
+    def resolve_items(self, info):
+        return [
+            {
+                "slot": slot,
+                "id": item.get("id"),
+                "internal_id": item.get("internalId"),
+                "name": item.get("name"),
+                "type": item.get("type"),
+                "level": item.get("level"),
+                "set": item.get("set"),
+            }
+            for slot, item in (self.get("items") or {}).items()
+        ]
+
+
+class BuildDiscoveryTiming(graphene.ObjectType):
+    name = graphene.String(required=True)
+    elapsed_ms = graphene.Float(required=True)
+
+
+class BuildDiscoveryDiagnostics(graphene.ObjectType):
+    elapsed_ms = graphene.Float()
+    cache_hit = graphene.Boolean()
+    app_cache_hit = graphene.Boolean()
+    result_count = graphene.Int(required=True)
+    solver = graphene.String()
+    cache_status = graphene.String()
+    solve_lock_acquired = graphene.Boolean()
+    lock_wait_ms = graphene.Float()
+    solver_status = graphene.String()
+    workers = graphene.Int()
+    item_count = graphene.Int()
+    candidate_count = graphene.Int()
+    max_shared_items = graphene.Int()
+    max_shared_items_enforced = graphene.Boolean()
+    timings = graphene.List(graphene.NonNull(BuildDiscoveryTiming), required=True)
+
+    def resolve_timings(self, info):
+        return [
+            {"name": name, "elapsed_ms": elapsed_ms}
+            for name, elapsed_ms in (self.get("timings") or {}).items()
+        ]
+
+
+class BuildDiscoveryCache(graphene.ObjectType):
+    status = graphene.String(required=True)
+    storage = graphene.String(required=True)
+    solver = graphene.String()
+
+
+class BuildDiscoveryTargetKinds(graphene.ObjectType):
+    ap = graphene.String(required=True)
+    mp = graphene.String(required=True)
+    range = graphene.String(required=True)
+
+    def resolve_ap(self, info):
+        return self["AP"]
+
+    def resolve_mp(self, info):
+        return self["MP"]
+
+    def resolve_range(self, info):
+        return self["Range"]
+
+
+class BuildDiscoveryTargetCaps(graphene.ObjectType):
+    ap = graphene.Int(required=True)
+    mp = graphene.Int(required=True)
+    range = graphene.Int(required=True)
+
+    def resolve_ap(self, info):
+        return self["AP"]
+
+    def resolve_mp(self, info):
+        return self["MP"]
+
+    def resolve_range(self, info):
+        return self["Range"]
+
+
+class BuildDiscoveryTargetSemantics(graphene.ObjectType):
+    type = graphene.String(required=True)
+    targets = graphene.Field(BuildDiscoveryTargetKinds, required=True)
+    caps = graphene.Field(BuildDiscoveryTargetCaps, required=True)
+    surplus_scoring = graphene.String(required=True)
+
+
+class BuildDiscoveryNoBuildReason(graphene.ObjectType):
+    code = graphene.String(required=True)
+    unavailable_item_ids = graphene.List(
+        graphene.NonNull(graphene.String), required=True
+    )
+    wrong_slot_item_ids = graphene.List(
+        graphene.NonNull(graphene.String), required=True
+    )
+
+
+class BuildDiscoveryResult(graphene.ObjectType):
+    status = graphene.Field(BuildDiscoveryStatus, required=True)
+    dataset_version = graphene.String(required=True)
+    solver_version = graphene.String(required=True)
+    cache_key = graphene.String()
+    query = graphene.Field(BuildDiscoveryQueryResult, required=True)
+    target_semantics = graphene.Field(BuildDiscoveryTargetSemantics, required=True)
+    warnings = graphene.List(graphene.NonNull(graphene.String), required=True)
+    no_build_reason = graphene.Field(BuildDiscoveryNoBuildReason)
+    diagnostics = graphene.Field(BuildDiscoveryDiagnostics, required=True)
+    cache = graphene.Field(BuildDiscoveryCache, required=True)
+    builds = graphene.List(graphene.NonNull(BuildDiscoveryBuild), required=True)
+
+
+class BuildDiscovery(graphene.Mutation):
+    class Arguments:
+        input = graphene.Argument(BuildDiscoveryInput, required=True)
+
+    Output = BuildDiscoveryResult
+
+    @tracer.wrap(name="BuildDiscovery.mutate")
+    @limiter.limit(
+        "6/minute",
+        error_message="Build Discovery request limit reached. Retry shortly.",
+    )
+    def mutate(self, info, input):
+        try:
+            query = build_discovery_query_from_input(input)
+            query.validate()
+            require_build_discovery_index()
+            response = build_discovery_cached_response(query)
+            return product_build_discovery_response(query, response)
+        except BuildDiscoverySolveLockTimeout:
+            raise GraphQLError("Build Discovery capacity is busy. Retry shortly.")
+        except ValueError as error:
+            raise GraphQLError(str(error))

--- a/server/app/build_discovery_promotion.py
+++ b/server/app/build_discovery_promotion.py
@@ -1,0 +1,197 @@
+import json
+from datetime import datetime, timezone
+
+import graphene
+from ddtrace import tracer
+from flask_babel import _
+from graphql import GraphQLError
+
+from app import session_scope
+from app.database.model_class_translation import ModelClassTranslation
+from app.database.model_generation_request import ModelGenerationRequest
+from app.database.model_item import ModelItem
+from app.token_utils import decode_token, encode_token
+from app.utils import (
+    edit_custom_set_metadata,
+    edit_custom_set_stats,
+    get_or_create_custom_set,
+    verified,
+)
+from oneoff.build_discovery_core import dataset_version, query_summary
+
+
+PROMOTION_TOKEN_SALT = "build-discovery-promotion-v1"
+PROMOTION_TOKEN_TTL_SECONDS = 3600
+MAX_GENERATION_REQUEST_PAYLOAD_BYTES = 20000
+
+
+def sign_build_discovery_candidate(query, response, build, *, rank=None):
+    return encode_token(
+        {
+            "source": "build_discovery",
+            "datasetVersion": response.get("datasetVersion") or dataset_version(),
+            "solverVersion": response.get("solverVersion"),
+            "query": query_summary(query),
+            "build": build,
+            "rank": rank,
+            "warnings": response.get("warnings") or [],
+        },
+        PROMOTION_TOKEN_SALT,
+    )
+
+
+def decode_build_discovery_promotion_token(token):
+    payload = decode_token(
+        token,
+        PROMOTION_TOKEN_SALT,
+        expiration=PROMOTION_TOKEN_TTL_SECONDS,
+    )
+    if not isinstance(payload, dict) or payload.get("source") != "build_discovery":
+        raise GraphQLError(_("This generated build has expired or is invalid."))
+    query = payload.get("query")
+    build = payload.get("build")
+    if not isinstance(query, dict) or not isinstance(build, dict):
+        raise GraphQLError(_("This generated build has expired or is invalid."))
+    return payload
+
+
+def validate_generation_request_payload(request_payload):
+    if request_payload is None:
+        return
+    try:
+        encoded_payload = json.dumps(request_payload, sort_keys=True)
+    except TypeError:
+        raise GraphQLError(_("Generation request payload is invalid."))
+    if len(encoded_payload.encode("utf-8")) > MAX_GENERATION_REQUEST_PAYLOAD_BYTES:
+        raise GraphQLError(_("Generation request payload is too large."))
+
+
+def generated_request_class_name(query):
+    if not isinstance(query, dict):
+        return None
+    class_name = query.get("className")
+    return class_name if isinstance(class_name, str) and class_name else None
+
+
+def generated_default_class_id(db_session, query):
+    class_name = generated_request_class_name(query)
+    if not class_name:
+        return None
+    translation = (
+        db_session.query(ModelClassTranslation)
+        .filter_by(locale="en", name=class_name)
+        .one_or_none()
+    )
+    return translation.class_id if translation else None
+
+
+def generated_build_stats(build):
+    base_allocation = build.get("baseAllocation") or {}
+    if not isinstance(base_allocation, dict):
+        raise GraphQLError(_("This generated build has invalid base characteristics."))
+    stat_names = ("vitality", "wisdom", "strength", "intelligence", "chance", "agility")
+    return {
+        **{f"scrolled_{stat}": 0 for stat in stat_names},
+        **{
+            f"base_{stat}": int(base_allocation.get(stat.title(), 0))
+            for stat in stat_names
+        },
+    }
+
+
+def generated_build_items(db_session, build):
+    item_payloads = build.get("items") or {}
+    exos = build.get("exos") or {}
+    if not isinstance(item_payloads, dict) or not item_payloads:
+        raise GraphQLError(_("Generated builds must include at least one item."))
+    if not isinstance(exos, dict):
+        raise GraphQLError(_("This generated build has invalid exomages."))
+
+    exo_item_ids = {
+        stat: exo.get("itemId") for stat, exo in exos.items() if isinstance(exo, dict)
+    }
+    items = []
+    for item_payload in item_payloads.values():
+        if not isinstance(item_payload, dict) or not item_payload.get("internalId"):
+            raise GraphQLError(_("This generated build is missing an item import ID."))
+        item = (
+            db_session.query(ModelItem)
+            .filter(ModelItem.uuid == item_payload["internalId"])
+            .one()
+        )
+        dofus_id = item_payload.get("id")
+        items.append(
+            {
+                "item": item,
+                "ap_exo": exo_item_ids.get("AP") == dofus_id,
+                "mp_exo": exo_item_ids.get("MP") == dofus_id,
+                "range_exo": exo_item_ids.get("Range") == dofus_id,
+            }
+        )
+    return items
+
+
+def create_import_generated_custom_set_mutation(
+    custom_set_type, generation_request_type
+):
+    class ImportGeneratedCustomSet(graphene.Mutation):
+        class Arguments:
+            name = graphene.NonNull(graphene.String)
+            promotion_token = graphene.NonNull(graphene.String)
+
+        custom_set = graphene.Field(custom_set_type, required=True)
+        generation_request = graphene.Field(generation_request_type, required=True)
+
+        @tracer.wrap(name="ImportGeneratedCustomSet.mutate")
+        @verified
+        def mutate(self, info, **kwargs):
+            payload = decode_build_discovery_promotion_token(
+                kwargs.get("promotion_token")
+            )
+            query = payload["query"]
+            build = payload["build"]
+            level = query.get("level")
+            if not isinstance(level, int):
+                raise GraphQLError(_("This generated build has an invalid level."))
+            request_payload = {
+                "generatedAt": datetime.now(timezone.utc).isoformat(),
+                "query": query,
+                "warnings": payload.get("warnings") or [],
+                "candidate": {
+                    "rank": payload.get("rank"),
+                    "score": build.get("score"),
+                    "itemIds": sorted(
+                        item.get("id")
+                        for item in (build.get("items") or {}).values()
+                        if isinstance(item, dict) and item.get("id")
+                    ),
+                    "exos": build.get("exos") or {},
+                    "baseAllocation": build.get("baseAllocation") or {},
+                },
+            }
+            validate_generation_request_payload(request_payload)
+
+            with session_scope() as db_session:
+                custom_set = get_or_create_custom_set(None, db_session)
+                edit_custom_set_metadata(custom_set, kwargs.get("name"), level)
+                edit_custom_set_stats(custom_set, generated_build_stats(build))
+                default_class_id = generated_default_class_id(db_session, query)
+                if default_class_id:
+                    custom_set.default_class_id = default_class_id
+                items = generated_build_items(db_session, build)
+                custom_set.equip_items(items, db_session)
+                generation_request = ModelGenerationRequest(
+                    custom_set_id=custom_set.uuid,
+                    source="build_discovery",
+                    dataset_version=payload.get("datasetVersion"),
+                    solver_version=payload.get("solverVersion"),
+                    request_payload=request_payload,
+                )
+                db_session.add(generation_request)
+
+            return ImportGeneratedCustomSet(
+                custom_set=custom_set,
+                generation_request=generation_request,
+            )
+
+    return ImportGeneratedCustomSet

--- a/server/app/build_discovery_service.py
+++ b/server/app/build_discovery_service.py
@@ -17,12 +17,12 @@ from oneoff.build_discovery_core import (
 )
 from oneoff.build_discovery_cpsat_runner import (
     CPSAT_SOLVER_VERSION,
-    DEFAULT_FAST_TIME_LIMIT_SECONDS,
+    DEFAULT_RELEASE_TIME_LIMIT_SECONDS,
     build_cpsat_args,
     solve_cpsat_query,
 )
 
-CPSAT_TIME_LIMIT_SECONDS = DEFAULT_FAST_TIME_LIMIT_SECONDS
+CPSAT_TIME_LIMIT_SECONDS = DEFAULT_RELEASE_TIME_LIMIT_SECONDS
 CPSAT_WORKERS = 2
 CPSAT_SOLVE_LOCK_KEY = "build_discovery:cpsat:solve_lock"
 CPSAT_SOLVE_LOCK_TIMEOUT_SECONDS = 30

--- a/server/app/build_discovery_service.py
+++ b/server/app/build_discovery_service.py
@@ -1,0 +1,282 @@
+"""Production integration boundary for CP-SAT Build Discovery."""
+
+import hashlib
+import json
+from copy import deepcopy
+from threading import Event, Thread
+from time import monotonic
+
+from dogpile.cache.api import NO_VALUE
+from redis.exceptions import LockError
+
+from oneoff.build_discovery_core import (
+    DEFAULT_MAX_SHARED_ITEMS,
+    BuildDiscoveryQuery,
+    dataset_version,
+    query_cache_identity,
+)
+from oneoff.build_discovery_cpsat_runner import (
+    CPSAT_SOLVER_VERSION,
+    DEFAULT_FAST_TIME_LIMIT_SECONDS,
+    build_cpsat_args,
+    solve_cpsat_query,
+)
+
+CPSAT_TIME_LIMIT_SECONDS = DEFAULT_FAST_TIME_LIMIT_SECONDS
+CPSAT_WORKERS = 2
+CPSAT_SOLVE_LOCK_KEY = "build_discovery:cpsat:solve_lock"
+CPSAT_SOLVE_LOCK_TIMEOUT_SECONDS = 30
+CPSAT_SOLVE_LOCK_BLOCKING_TIMEOUT_SECONDS = 6
+CPSAT_SYNC_SOLVE_LOCK_BLOCKING_TIMEOUT_SECONDS = 0.2
+CPSAT_CACHE_PREFIX = "build_discovery_response:cpsat:"
+
+
+class BuildDiscoverySolveLockTimeout(RuntimeError):
+    def __init__(self, message, lock_wait_ms):
+        super().__init__(message)
+        self.lock_wait_ms = lock_wait_ms
+
+
+class BuildDiscoverySolveLockLost(RuntimeError):
+    pass
+
+
+def compact_product_response(response):
+    """Remove solver-only debug data before Redis and GraphQL serialization."""
+    result = dict(response)
+    for key in (
+        "build",
+        "candidateSummaries",
+        "effectiveScoringStats",
+        "objectiveWeights",
+    ):
+        result.pop(key, None)
+    compact_attempts = [
+        {
+            key: attempt[key]
+            for key in ("attempt", "mode", "status", "modelMs", "solveMs", "objective")
+            if key in attempt
+        }
+        for attempt in result.get("attempts") or ()
+    ]
+    result["attempts"] = compact_attempts
+    diagnostics = dict(result.get("diagnostics") or {})
+    diagnostics["attempts"] = compact_attempts
+    diagnostics.pop("objectiveWeights", None)
+    result["diagnostics"] = diagnostics
+    return result
+
+
+class _RenewableSolveLock:
+    def __init__(self, lock, lease_seconds, renewal_interval_seconds=None):
+        self.lock = lock
+        self.renewal_interval_seconds = renewal_interval_seconds or lease_seconds / 3.0
+        self.stop_event = Event()
+        self.renewal_error = None
+        self.thread = None
+
+    def start(self):
+        self.thread = Thread(
+            target=self._renew,
+            name="build-discovery-solve-lock-renewal",
+            daemon=True,
+        )
+        self.thread.start()
+
+    def _renew(self):
+        while not self.stop_event.wait(self.renewal_interval_seconds):
+            try:
+                if not self.lock.extend(self.renewal_interval_seconds * 3.0):
+                    raise LockError("solve lock renewal was rejected")
+            except Exception as error:
+                self.renewal_error = error
+                self.stop_event.set()
+                return
+
+    def stop_and_join(self):
+        self.stop_event.set()
+        if self.thread is not None:
+            self.thread.join()
+
+    def raise_if_lost(self):
+        if self.renewal_error is not None:
+            raise BuildDiscoverySolveLockLost(
+                "CP-SAT solve lock ownership could not be renewed."
+            ) from self.renewal_error
+
+
+def build_discovery_query_from_payload(payload):
+    query_payload = (
+        (payload or {}).get("queryIdentity") or (payload or {}).get("query") or {}
+    )
+    return BuildDiscoveryQuery(
+        class_name=query_payload.get("className", "Iop"),
+        level=query_payload.get("level", 200),
+        elements=tuple(query_payload.get("elements", ("strength",))),
+        mode=query_payload.get("mode", "pvm"),
+        ap_target=query_payload.get("apTarget", 11),
+        mp_target=query_payload.get("mpTarget", 6),
+        range_target=query_payload.get("rangeTarget", 0),
+        damage_survivability_preset=query_payload.get("damageSurvivabilityPreset", 3),
+        budget_tier=query_payload.get("budgetTier", 2),
+        exo_policy=query_payload.get("exoPolicy", "allow"),
+        weapon_policy=query_payload.get("weaponPolicy", "stat_stick_allowed"),
+        locked_item_ids=tuple(query_payload.get("lockedItemIds", ())),
+        avoided_item_ids=tuple(query_payload.get("avoidedItemIds", ())),
+        limit=query_payload.get("limit", 5),
+        max_shared_items=query_payload.get("maxSharedItems", DEFAULT_MAX_SHARED_ITEMS),
+    )
+
+
+def build_discovery_app_cache_key(query, current_dataset_version=None):
+    dataset = current_dataset_version or dataset_version()
+    payload = {
+        "solverVersion": CPSAT_SOLVER_VERSION,
+        "datasetVersion": dataset,
+        "query": query_cache_identity(query),
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return CPSAT_CACHE_PREFIX + digest
+
+
+def _cached_value(cache_region, cache_key):
+    response = cache_region.get(cache_key)
+    return None if response is None or response is NO_VALUE else response
+
+
+def _with_cache_diagnostics(
+    response,
+    status,
+    *,
+    cache_key,
+    current_dataset_version,
+    lock_acquired=False,
+    lock_wait_ms=0.0,
+):
+    result = deepcopy(response)
+    result["solver"] = "cpsat"
+    result["solverVersion"] = CPSAT_SOLVER_VERSION
+    result["datasetVersion"] = current_dataset_version
+    result["cacheKey"] = cache_key
+    result["cache"] = {
+        **result.get("cache", {}),
+        "status": status,
+        "storage": "app_cache",
+        "solver": "cpsat",
+    }
+    diagnostics = result.setdefault("diagnostics", {})
+    diagnostics["solver"] = "cpsat"
+    diagnostics["cacheStatus"] = status
+    diagnostics["appCacheHit"] = status in {"hit", "deduplicated"}
+    diagnostics["solveLockAcquired"] = lock_acquired
+    diagnostics["lockWaitMs"] = round(lock_wait_ms, 3)
+    if status == "hit":
+        diagnostics["cacheHit"] = True
+    elif status == "deduplicated":
+        diagnostics["cacheHit"] = True
+    return result
+
+
+def build_discovery_cached_response_hit(query, cache_region=None):
+    if cache_region is None:
+        from app import cache_region as app_cache_region
+
+        cache_region = app_cache_region
+    current_dataset_version = dataset_version()
+    cache_key = build_discovery_app_cache_key(query, current_dataset_version)
+    cached = _cached_value(cache_region, cache_key)
+    if cached is None:
+        return None
+    return _with_cache_diagnostics(
+        cached,
+        "hit",
+        cache_key=cache_key,
+        current_dataset_version=current_dataset_version,
+    )
+
+
+def build_discovery_cached_response(
+    query,
+    cache_region=None,
+    redis_client=None,
+    solve_fn=solve_cpsat_query,
+    lock_blocking_timeout_seconds=CPSAT_SOLVE_LOCK_BLOCKING_TIMEOUT_SECONDS,
+    lock_timeout_seconds=CPSAT_SOLVE_LOCK_TIMEOUT_SECONDS,
+    lock_renewal_interval_seconds=None,
+):
+    if cache_region is None or redis_client is None:
+        from app import cache as app_redis_client, cache_region as app_cache_region
+
+        cache_region = cache_region or app_cache_region
+        redis_client = redis_client or app_redis_client
+
+    current_dataset_version = dataset_version()
+    cache_key = build_discovery_app_cache_key(query, current_dataset_version)
+    cached = _cached_value(cache_region, cache_key)
+    if cached is not None:
+        return _with_cache_diagnostics(
+            cached,
+            "hit",
+            cache_key=cache_key,
+            current_dataset_version=current_dataset_version,
+        )
+
+    solve_lock = redis_client.lock(
+        CPSAT_SOLVE_LOCK_KEY,
+        timeout=lock_timeout_seconds,
+        blocking_timeout=lock_blocking_timeout_seconds,
+        thread_local=False,
+    )
+    lock_wait_started = monotonic()
+    if not solve_lock.acquire(blocking=True):
+        lock_wait_ms = (monotonic() - lock_wait_started) * 1000.0
+        raise BuildDiscoverySolveLockTimeout(
+            "CP-SAT solve capacity unavailable after "
+            f"{lock_blocking_timeout_seconds}s.",
+            lock_wait_ms=lock_wait_ms,
+        )
+    lock_wait_ms = (monotonic() - lock_wait_started) * 1000.0
+    renewable_lock = _RenewableSolveLock(
+        solve_lock, lock_timeout_seconds, lock_renewal_interval_seconds
+    )
+    renewable_lock.start()
+    try:
+        cached = _cached_value(cache_region, cache_key)
+        if cached is not None:
+            return _with_cache_diagnostics(
+                cached,
+                "deduplicated",
+                cache_key=cache_key,
+                current_dataset_version=current_dataset_version,
+                lock_acquired=True,
+                lock_wait_ms=lock_wait_ms,
+            )
+
+        args = build_cpsat_args(
+            query,
+            time_limit_seconds=CPSAT_TIME_LIMIT_SECONDS,
+            workers=CPSAT_WORKERS,
+        )
+        solved = compact_product_response(solve_fn(query, args))
+        renewable_lock.stop_and_join()
+        renewable_lock.raise_if_lost()
+        response = _with_cache_diagnostics(
+            solved,
+            "miss",
+            cache_key=cache_key,
+            current_dataset_version=current_dataset_version,
+            lock_acquired=True,
+            lock_wait_ms=lock_wait_ms,
+        )
+        cache_region.set(cache_key, response)
+        return response
+    finally:
+        renewable_lock.stop_and_join()
+        try:
+            solve_lock.release()
+        except LockError:
+            # Redis locks release by token, so an expired/reassigned lock is never
+            # deleted by its former owner.
+            pass

--- a/server/app/database/model_custom_set.py
+++ b/server/app/database/model_custom_set.py
@@ -6,6 +6,7 @@ from .base import Base
 from .model_item import ModelItem
 from .model_equipped_item import ModelEquippedItem
 from .model_equipped_item_exo import ModelEquippedItemExo
+from .model_generation_request import ModelGenerationRequest
 from .model_item_slot import ModelItemSlot
 from .model_custom_set_stat import ModelCustomSetStat
 from .model_custom_set_tag_association import ModelCustomSetTagAssociation
@@ -65,6 +66,12 @@ class ModelCustomSet(Base):
     )
     children_custom_sets = relationship("ModelCustomSet")
     default_class = relationship("ModelClass")
+    generation_request = relationship(
+        "ModelGenerationRequest",
+        back_populates="custom_set",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
 
     tags = relationship(
         "ModelCustomSetTag",

--- a/server/app/database/model_generation_request.py
+++ b/server/app/database/model_generation_request.py
@@ -1,0 +1,31 @@
+import sqlalchemy
+from datetime import datetime
+from sqlalchemy import Column, DateTime, ForeignKey, JSON, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class ModelGenerationRequest(Base):
+    __tablename__ = "generation_request"
+
+    uuid = Column(
+        UUID(as_uuid=True),
+        server_default=sqlalchemy.text("uuid_generate_v4()"),
+        primary_key=True,
+        nullable=False,
+    )
+    custom_set_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("custom_set.uuid", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    source = Column("source", String(80), nullable=False, index=True)
+    dataset_version = Column("dataset_version", String(120))
+    solver_version = Column("solver_version", String(120))
+    request_payload = Column("request_payload", JSON)
+    creation_date = Column("creation_date", DateTime, default=datetime.utcnow)
+
+    custom_set = relationship("ModelCustomSet", back_populates="generation_request")

--- a/server/app/loaders.py
+++ b/server/app/loaders.py
@@ -21,6 +21,7 @@ from app.database.model_weapon_stat import ModelWeaponStat
 from app.database.model_weapon_effect import ModelWeaponEffect
 from app.database.model_custom_set_tag_association import ModelCustomSetTagAssociation
 from app.database.model_custom_set_tag_translation import ModelCustomSetTagTranslation
+from app.database.model_generation_request import ModelGenerationRequest
 from app.database.model_equipped_item import ModelEquippedItem
 from app.database.model_equipped_item_exo import ModelEquippedItemExo
 from app.database.model_spell_variant_pair import ModelSpellVariantPair
@@ -657,6 +658,27 @@ def load_custom_set_tag_associations(custom_set_ids):
 class CustomSetTagAssociationLoader(DataLoader):
     def batch_load_fn(self, custom_set_ids):
         return load_custom_set_tag_associations(custom_set_ids)
+
+
+def load_generation_requests(custom_set_ids):
+    generation_request_by_custom_set_id = {}
+    for generation_request in db.session.query(ModelGenerationRequest).filter(
+        ModelGenerationRequest.custom_set_id.in_(custom_set_ids)
+    ):
+        generation_request_by_custom_set_id[
+            generation_request.custom_set_id
+        ] = generation_request
+    return Promise.resolve(
+        [
+            generation_request_by_custom_set_id.get(custom_set_id, None)
+            for custom_set_id in custom_set_ids
+        ]
+    )
+
+
+class GenerationRequestLoader(DataLoader):
+    def batch_load_fn(self, custom_set_ids):
+        return load_generation_requests(custom_set_ids)
 
 
 def load_custom_set_tag_translations(tag_ids):

--- a/server/app/migrations/versions/395c1a102439_add_generation_request.py
+++ b/server/app/migrations/versions/395c1a102439_add_generation_request.py
@@ -1,0 +1,56 @@
+"""Add generation request provenance
+
+Revision ID: 395c1a102439
+Revises: 1cb498f44c5b
+Create Date: 2026-07-09 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "395c1a102439"
+down_revision = "1cb498f44c5b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "generation_request",
+        sa.Column(
+            "uuid",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+        sa.Column("custom_set_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("source", sa.String(length=80), nullable=False),
+        sa.Column("dataset_version", sa.String(length=120), nullable=True),
+        sa.Column("solver_version", sa.String(length=120), nullable=True),
+        sa.Column("request_payload", sa.JSON(), nullable=True),
+        sa.Column("creation_date", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["custom_set_id"],
+            ["custom_set.uuid"],
+            name=op.f("fk_generation_request_custom_set_id_custom_set"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("uuid", name=op.f("pk_generation_request")),
+        sa.UniqueConstraint(
+            "custom_set_id",
+            name=op.f("uq_generation_request_custom_set_id"),
+        ),
+    )
+    op.create_index(
+        op.f("ix_generation_request_source"),
+        "generation_request",
+        ["source"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_generation_request_source"), table_name="generation_request")
+    op.drop_table("generation_request")

--- a/server/app/schema.py
+++ b/server/app/schema.py
@@ -34,6 +34,7 @@ from app.database.model_custom_set_tag_association import ModelCustomSetTagAssoc
 from app.database.model_equipped_item_exo import ModelEquippedItemExo
 from app.database.model_equipped_item import ModelEquippedItem
 from app.database.model_custom_set import ModelCustomSet, MAX_NAME_LENGTH
+from app.database.model_generation_request import ModelGenerationRequest
 from app.database.model_user import ModelUserAccount
 from app.database.model_spell_effect import ModelSpellEffect
 from app.database.model_spell_effect_condition_translation import (
@@ -46,7 +47,6 @@ from app.database.model_spell_translation import ModelSpellTranslation
 from app.database.model_spell import ModelSpell
 from app.database.model_spell_variant_pair import ModelSpellVariantPair
 from app.database.model_user_setting import ModelUserSetting
-from app.database.model_class_translation import ModelClassTranslation
 from app.database.model_class import ModelClass
 from app.suggester.suggester import get_ordered_suggestions
 from app.tasks import send_email
@@ -78,6 +78,7 @@ from app.database.enums import (
 from app.token_utils import decode_token, encode_token, generate_verify_email_url
 import app.mutation_validation_utils as validation
 import graphene
+from graphene.types.generic import GenericScalar
 import pytz
 from graphql import GraphQLError
 from flask import session, render_template, g
@@ -89,6 +90,10 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.sql.expression import true
 from datetime import datetime
 from ddtrace import tracer
+from app.build_discovery_graphql import BuildDiscovery
+from app.build_discovery_promotion import (
+    create_import_generated_custom_set_mutation,
+)
 
 # workaround from https://github.com/graphql-python/graphene-sqlalchemy/issues/211
 # without this workaround, graphene complains that there are multiple
@@ -376,6 +381,7 @@ class CustomSetTagAssociation(SQLAlchemyObjectType):
 
 class CustomSet(SQLAlchemyObjectType):
     equipped_items = graphene.NonNull(graphene.List(graphene.NonNull(EquippedItem)))
+    generation_request = graphene.Field(lambda: GenerationRequest)
 
     def resolve_equipped_items(self, info):
         return g.dataloaders.get("equipped_item_loader").load(self.uuid)
@@ -406,8 +412,97 @@ class CustomSet(SQLAlchemyObjectType):
             return False
         return True
 
+    @tracer.wrap(name="CustomSet.resolve_generation_request")
+    def resolve_generation_request(self, info):
+        return g.dataloaders.get("generation_request_loader").load(self.uuid)
+
     class Meta:
         model = ModelCustomSet
+        interfaces = (GlobalNode,)
+
+
+def generation_request_query_metadata(generation_request):
+    payload = generation_request.request_payload
+    if not isinstance(payload, dict):
+        return {}
+    query = payload.get("query")
+    return query if isinstance(query, dict) else {}
+
+
+def readable_generation_source(source):
+    if source == "build_discovery":
+        return "Build Discovery"
+    return " ".join(part.capitalize() for part in source.split("_") if part)
+
+
+class GenerationRequest(SQLAlchemyObjectType):
+    request_payload = GenericScalar()
+    source_label = graphene.String(required=True)
+    query_class_name = graphene.String()
+    query_elements = graphene.List(graphene.NonNull(graphene.String), required=True)
+    query_ap_target = graphene.Int()
+    query_mp_target = graphene.Int()
+    query_range_target = graphene.Int()
+    display_summary = graphene.String(required=True)
+
+    def resolve_source_label(self, info):
+        return readable_generation_source(self.source)
+
+    def resolve_query_class_name(self, info):
+        query = generation_request_query_metadata(self)
+        class_name = query.get("className")
+        return class_name if isinstance(class_name, str) else None
+
+    def resolve_query_elements(self, info):
+        query = generation_request_query_metadata(self)
+        elements = query.get("elements")
+        if not isinstance(elements, list):
+            return []
+        return [element for element in elements if isinstance(element, str)]
+
+    def resolve_query_ap_target(self, info):
+        query = generation_request_query_metadata(self)
+        value = query.get("apTarget")
+        return value if isinstance(value, int) else None
+
+    def resolve_query_mp_target(self, info):
+        query = generation_request_query_metadata(self)
+        value = query.get("mpTarget")
+        return value if isinstance(value, int) else None
+
+    def resolve_query_range_target(self, info):
+        query = generation_request_query_metadata(self)
+        value = query.get("rangeTarget")
+        return value if isinstance(value, int) else None
+
+    def resolve_display_summary(self, info):
+        context = [
+            GenerationRequest.resolve_query_class_name(self, info),
+            "/".join(GenerationRequest.resolve_query_elements(self, info)),
+        ]
+        action_stats = (
+            GenerationRequest.resolve_query_ap_target(self, info),
+            GenerationRequest.resolve_query_mp_target(self, info),
+            GenerationRequest.resolve_query_range_target(self, info),
+        )
+        if all(value is not None for value in action_stats):
+            context.append("{}/{}/{}".format(*action_stats))
+        versions = [
+            f"dataset {self.dataset_version}" if self.dataset_version else None,
+            f"solver {self.solver_version}" if self.solver_version else None,
+        ]
+        return " - ".join(
+            part
+            for part in [
+                GenerationRequest.resolve_source_label(self, info),
+                " ".join(part for part in context if part),
+                " - ".join(part for part in versions if part),
+            ]
+            if part
+        )
+
+    class Meta:
+        model = ModelGenerationRequest
         interfaces = (GlobalNode,)
 
 
@@ -847,6 +942,11 @@ class EquipMultipleItems(graphene.Mutation):
             custom_set.equip_items(items, db_session)
 
         return EquipMultipleItems(custom_set=custom_set)
+
+
+ImportGeneratedCustomSet = create_import_generated_custom_set_mutation(
+    CustomSet, GenerationRequest
+)
 
 
 class MageEquippedItem(graphene.Mutation):
@@ -1812,6 +1912,8 @@ class Mutation(graphene.ObjectType):
     edit_custom_set_stats = EditCustomSetStats.Field()
     equip_set = EquipSet.Field()
     equip_multiple_items = EquipMultipleItems.Field()
+    import_generated_custom_set = ImportGeneratedCustomSet.Field()
+    build_discovery = BuildDiscovery.Field(required=True)
     create_custom_set = CreateCustomSet.Field()
     resend_verification_email = ResendVerificationEmail.Field()
     change_locale = ChangeLocale.Field()

--- a/server/app/tasks.py
+++ b/server/app/tasks.py
@@ -1,10 +1,8 @@
-import time
 import boto3
 import os
 
 from app import session_scope
 from app.database.model_user import ModelUserAccount
-from flask_babel import _
 
 
 def send_email(email, subject, content):

--- a/server/scripts/test_build_discovery_graphql.py
+++ b/server/scripts/test_build_discovery_graphql.py
@@ -1,0 +1,315 @@
+"""GraphQL contract tests for synchronous Build Discovery."""
+
+import importlib
+import unittest
+import uuid
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+schema_module = importlib.import_module("app.schema")
+graphql_module = importlib.import_module("app.build_discovery_graphql")
+promotion_module = importlib.import_module("app.build_discovery_promotion")
+app_module = importlib.import_module("app")
+utils_module = importlib.import_module("app.utils")
+schema = schema_module.schema
+
+
+@contextmanager
+def mocked_session_scope(db_session):
+    yield db_session
+
+
+def query_input(**overrides):
+    value = {
+        "className": "Iop",
+        "level": 200,
+        "element": "strength",
+        "apTarget": 11,
+        "mpTarget": 6,
+        "rangeTarget": None,
+        "damageSurvivabilityPreset": 3,
+        "budgetTier": 2,
+        "exoPolicy": "allow",
+        "weaponPolicy": "stat_stick_allowed",
+        "lockedItemIds": [],
+        "avoidedItemIds": [],
+        "resultLimit": 3,
+    }
+    value.update(overrides)
+    return value
+
+
+def generated_build(item_id=None):
+    item_id = item_id or str(uuid.uuid4())
+    return {
+        "score": 123.0,
+        "baseAllocation": {"Strength": 300},
+        "conditionFailures": [],
+        "totals": {"AP": 11, "MP": 6},
+        "sets": {},
+        "exos": {"AP": {"itemId": "100", "slot": "ring_1"}},
+        "items": {
+            "ring_1": {
+                "id": "100",
+                "internalId": item_id,
+                "name": "Test Ring",
+                "type": "Ring",
+                "level": 200,
+                "set": None,
+            }
+        },
+    }
+
+
+class BuildDiscoveryGraphQLTest(unittest.TestCase):
+    def setUp(self):
+        self.request_context = app_module.app.test_request_context(
+            "/graphql", environ_base={"REMOTE_ADDR": "192.0.2.10"}
+        )
+        self.request_context.push()
+
+    def tearDown(self):
+        self.request_context.pop()
+
+    def test_build_discovery_is_typed_synchronous_and_preserves_null_range(self):
+        response = {
+            "status": "complete",
+            "datasetVersion": "dataset-v1",
+            "solverVersion": "solver-v1",
+            "cacheKey": "cache-key",
+            "cache": {"status": "miss", "storage": "app_cache", "solver": "cpsat"},
+            "diagnostics": {"elapsedMs": 12.5, "resultCount": 1},
+            "warnings": [],
+            "builds": [generated_build()],
+        }
+        with patch.object(
+            graphql_module, "require_build_discovery_index"
+        ), patch.object(
+            graphql_module, "build_discovery_cached_response", return_value=response
+        ) as solve, patch.object(
+            graphql_module,
+            "sign_build_discovery_candidate",
+            return_value="signed",
+        ):
+            result = schema.execute(
+                """
+                mutation Discover($input: BuildDiscoveryInput!) {
+                  buildDiscovery(input: $input) {
+                    status datasetVersion solverVersion cacheKey
+                    query { className rangeTarget resultLimit }
+                    diagnostics { elapsedMs resultCount }
+                    builds {
+                      promotionToken score
+                      baseAllocation { name value }
+                      totals { name value }
+                      exos { stat itemId slot }
+                      items { slot id internalId name type level set }
+                    }
+                  }
+                }
+                """,
+                variables={"input": query_input()},
+            )
+
+        self.assertIsNone(result.errors)
+        payload = result.data["buildDiscovery"]
+        self.assertEqual(payload["status"], "COMPLETE")
+        self.assertIsNone(payload["query"]["rangeTarget"])
+        self.assertEqual(payload["builds"][0]["promotionToken"], "signed")
+        self.assertEqual(payload["builds"][0]["baseAllocation"][0]["value"], 300.0)
+        self.assertIsNone(solve.call_args.args[0].range_target)
+
+    def test_no_valid_build_is_a_domain_result(self):
+        response = {
+            "status": "no_valid_build",
+            "datasetVersion": "dataset-v1",
+            "solverVersion": "solver-v1",
+            "cache": {"status": "miss", "storage": "app_cache"},
+            "diagnostics": {"resultCount": 0},
+            "warnings": ["No build satisfies these constraints."],
+            "noBuildReason": {"code": "infeasible"},
+            "builds": [],
+        }
+        with patch.object(
+            graphql_module, "require_build_discovery_index"
+        ), patch.object(
+            graphql_module, "build_discovery_cached_response", return_value=response
+        ):
+            result = schema.execute(
+                """
+                mutation Discover($input: BuildDiscoveryInput!) {
+                  buildDiscovery(input: $input) {
+                    status warnings builds { score }
+                    noBuildReason { code }
+                  }
+                }
+                """,
+                variables={"input": query_input()},
+            )
+
+        self.assertIsNone(result.errors)
+        self.assertEqual(result.data["buildDiscovery"]["status"], "NO_VALID_BUILD")
+        self.assertEqual(result.data["buildDiscovery"]["builds"], [])
+
+    def test_public_input_is_bounded_and_has_no_solver_tuning(self):
+        result = schema.execute(
+            """
+            query Contract {
+              __schema {
+                queryType { fields { name } }
+                mutationType { fields { name } }
+              }
+              __type(name: "BuildDiscoveryInput") { inputFields { name } }
+              customSetFilters: __type(name: "CustomSetFilters") {
+                inputFields { name }
+              }
+            }
+            """
+        )
+        self.assertIsNone(result.errors)
+        query_fields = {
+            field["name"] for field in result.data["__schema"]["queryType"]["fields"]
+        }
+        mutation_fields = {
+            field["name"] for field in result.data["__schema"]["mutationType"]["fields"]
+        }
+        input_fields = {field["name"] for field in result.data["__type"]["inputFields"]}
+        custom_set_filter_fields = {
+            field["name"] for field in result.data["customSetFilters"]["inputFields"]
+        }
+        self.assertNotIn("buildDiscoveryJob", query_fields)
+        self.assertIn("buildDiscovery", mutation_fields)
+        self.assertNotIn("startBuildDiscovery", mutation_fields)
+        self.assertNotIn("generated", custom_set_filter_fields)
+        self.assertTrue(
+            {"topK", "beamWidth", "perSignatureCap", "relevantSetLimit"}.isdisjoint(
+                input_fields
+            )
+        )
+
+        for limit in (0, 6):
+            with self.subTest(limit=limit):
+                bounded = schema.execute(
+                    """
+                    mutation Discover($input: BuildDiscoveryInput!) {
+                      buildDiscovery(input: $input) { status }
+                    }
+                    """,
+                    variables={"input": query_input(resultLimit=limit)},
+                )
+                self.assertIn(
+                    "resultLimit must be between 1 and 5", str(bounded.errors[0])
+                )
+
+        for max_shared_items in (-1, 17):
+            with self.subTest(max_shared_items=max_shared_items):
+                bounded = schema.execute(
+                    """
+                    mutation Discover($input: BuildDiscoveryInput!) {
+                      buildDiscovery(input: $input) { status }
+                    }
+                    """,
+                    variables={
+                        "input": query_input(maxSharedItems=max_shared_items)
+                    },
+                )
+                self.assertIn(
+                    "maxSharedItems must be between 0 and 16",
+                    str(bounded.errors[0]),
+                )
+
+        for field_name in ("lockedItemIds", "avoidedItemIds"):
+            with self.subTest(field_name=field_name):
+                controlled = schema.execute(
+                    """
+                    mutation Discover($input: BuildDiscoveryInput!) {
+                      buildDiscovery(input: $input) { status }
+                    }
+                    """,
+                    variables={"input": query_input(**{field_name: ["1"] * 51})},
+                )
+                self.assertIn(
+                    f"{field_name} cannot contain more than 50 items",
+                    str(controlled.errors[0]),
+                )
+
+    def test_promotion_uses_signed_server_candidate_atomically(self):
+        item_id = uuid.uuid4()
+        class_id = uuid.uuid4()
+        custom_set = SimpleNamespace(
+            uuid=uuid.uuid4(), default_class_id=None, equip_items=Mock()
+        )
+        item = SimpleNamespace(uuid=item_id)
+        db_session = Mock()
+        db_session.query.return_value.filter.return_value.one.return_value = item
+        payload = {
+            "source": "build_discovery",
+            "datasetVersion": "dataset-v1",
+            "solverVersion": "solver-v1",
+            "query": {"className": "Iop", "level": 200, "elements": ["strength"]},
+            "build": generated_build(str(item_id)),
+        }
+        verified_user = SimpleNamespace(
+            is_authenticated=True,
+            _get_current_object=lambda: SimpleNamespace(verified=True),
+        )
+
+        with patch.object(
+            promotion_module,
+            "decode_build_discovery_promotion_token",
+            return_value=payload,
+        ), patch.object(
+            promotion_module,
+            "session_scope",
+            return_value=mocked_session_scope(db_session),
+        ), patch.object(
+            promotion_module, "get_or_create_custom_set", return_value=custom_set
+        ), patch.object(
+            promotion_module, "edit_custom_set_metadata"
+        ) as edit_metadata, patch.object(
+            promotion_module, "edit_custom_set_stats"
+        ) as edit_stats, patch.object(
+            promotion_module, "generated_default_class_id", return_value=class_id
+        ), patch.object(
+            utils_module, "current_user", verified_user
+        ):
+            result = schema.execute(
+                """
+                mutation Promote($token: String!) {
+                  importGeneratedCustomSet(
+                    name: "Generated Strength Iop"
+                    promotionToken: $token
+                  ) {
+                    generationRequest { source datasetVersion solverVersion }
+                  }
+                }
+                """,
+                variables={"token": "signed"},
+            )
+
+        self.assertIsNone(result.errors)
+        edit_metadata.assert_called_once_with(custom_set, "Generated Strength Iop", 200)
+        self.assertEqual(edit_stats.call_args.args[1]["base_strength"], 300)
+        self.assertEqual(custom_set.default_class_id, class_id)
+        equipped = custom_set.equip_items.call_args.args[0][0]
+        self.assertTrue(equipped["ap_exo"])
+        generation_request = db_session.add.call_args.args[0]
+        self.assertEqual(generation_request.source, "build_discovery")
+        self.assertEqual(generation_request.dataset_version, "dataset-v1")
+
+    def test_invalid_or_expired_promotion_token_is_rejected(self):
+        with patch.object(
+            promotion_module, "decode_token", return_value=False
+        ) as decode:
+            with self.assertRaisesRegex(Exception, "expired or is invalid"):
+                promotion_module.decode_build_discovery_promotion_token("tampered")
+        decode.assert_called_once_with(
+            "tampered",
+            promotion_module.PROMOTION_TOKEN_SALT,
+            expiration=3600,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/scripts/test_build_discovery_service.py
+++ b/server/scripts/test_build_discovery_service.py
@@ -1,0 +1,512 @@
+import importlib
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from threading import Condition, Lock
+from time import monotonic, sleep
+from unittest.mock import Mock, patch
+
+from graphql import GraphQLError
+from redis.exceptions import LockError
+
+from app import build_discovery_service as service
+from oneoff.build_discovery_core import BuildDiscoveryQuery
+
+
+class FakeCache:
+    def __init__(self, values=None):
+        self.values = list(values or [])
+        self.stored = {}
+        self.get_keys = []
+
+    def get(self, key):
+        self.get_keys.append(key)
+        if self.values:
+            return self.values.pop(0)
+        return self.stored.get(key)
+
+    def set(self, key, value):
+        self.stored[key] = value
+
+
+class FakeLock:
+    def __init__(self, acquired=True):
+        self.acquired = acquired
+        self.acquire_calls = []
+        self.released = False
+        self.extend_calls = []
+
+    def acquire(self, **kwargs):
+        self.acquire_calls.append(kwargs)
+        return self.acquired
+
+    def release(self):
+        self.released = True
+
+    def extend(self, seconds):
+        self.extend_calls.append(seconds)
+        return True
+
+
+class BuildDiscoveryProductResponseTest(unittest.TestCase):
+    def test_compacts_duplicate_and_solver_only_debug_fields(self):
+        response = service.compact_product_response(
+            {
+                "status": "complete",
+                "build": {"score": 1},
+                "builds": [{"score": 1}],
+                "candidateSummaries": [{"score": 1}],
+                "effectiveScoringStats": {"Strength": 1000},
+                "objectiveWeights": {"Strength": 1.0},
+                "attempts": [
+                    {
+                        "attempt": 1,
+                        "status": "FEASIBLE",
+                        "solveMs": 3000,
+                        "callbackCandidateEvents": [{"large": "payload"}],
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(response["builds"], [{"score": 1}])
+        self.assertNotIn("build", response)
+        self.assertNotIn("candidateSummaries", response)
+        self.assertNotIn("objectiveWeights", response)
+        self.assertEqual(
+            response["attempts"],
+            [{"attempt": 1, "status": "FEASIBLE", "solveMs": 3000}],
+        )
+
+
+class LostOwnershipLock(FakeLock):
+    def release(self):
+        raise LockError("lock is no longer owned")
+
+
+class FakeRedis:
+    def __init__(self, lock=None):
+        self.fake_lock = lock or FakeLock()
+        self.calls = []
+
+    def lock(self, key, **kwargs):
+        self.calls.append((key, kwargs))
+        return self.fake_lock
+
+
+class SharedFakeRedis:
+    def __init__(self):
+        self.mutex = Lock()
+
+    def lock(self, key, **kwargs):
+        mutex = self.mutex
+
+        class SharedFakeLock:
+            def acquire(self, **acquire_kwargs):
+                return mutex.acquire(timeout=kwargs["blocking_timeout"])
+
+            def release(self):
+                mutex.release()
+
+            def extend(self, seconds):
+                return True
+
+        return SharedFakeLock()
+
+
+class ExpiringFakeRedis:
+    def __init__(self):
+        self.condition = Condition()
+        self.owner = None
+        self.deadline = 0.0
+
+    def lock(self, key, **kwargs):
+        redis = self
+        token = object()
+        lease_seconds = kwargs["timeout"]
+
+        class ExpiringFakeLock:
+            def acquire(self, **acquire_kwargs):
+                wait_deadline = monotonic() + kwargs["blocking_timeout"]
+                with redis.condition:
+                    while redis.owner is not None and redis.deadline > monotonic():
+                        remaining = min(
+                            redis.deadline - monotonic(), wait_deadline - monotonic()
+                        )
+                        if remaining <= 0:
+                            return False
+                        redis.condition.wait(remaining)
+                    redis.owner = token
+                    redis.deadline = monotonic() + lease_seconds
+                    return True
+
+            def extend(self, seconds):
+                with redis.condition:
+                    if redis.owner is not token or redis.deadline <= monotonic():
+                        raise LockError("lock expired")
+                    redis.deadline += seconds
+                    redis.condition.notify_all()
+                    return True
+
+            def release(self):
+                with redis.condition:
+                    if redis.owner is not token or redis.deadline <= monotonic():
+                        raise LockError("lock is no longer owned")
+                    redis.owner = None
+                    redis.condition.notify_all()
+
+        return ExpiringFakeLock()
+
+
+def response():
+    return {
+        "status": "complete",
+        "datasetVersion": "dataset-v1",
+        "diagnostics": {"elapsedMs": 12.0},
+    }
+
+
+class BuildDiscoveryServiceTest(unittest.TestCase):
+    def setUp(self):
+        self.query = BuildDiscoveryQuery(class_name="Iop", elements=("strength",))
+        self.dataset_patch = patch.object(
+            service, "dataset_version", return_value="dataset-v1"
+        )
+        self.dataset_patch.start()
+        self.addCleanup(self.dataset_patch.stop)
+
+    def test_cache_hit_is_lock_free_and_exposes_diagnostics(self):
+        cache = FakeCache([response()])
+        redis = FakeRedis()
+        solve = Mock()
+
+        result = service.build_discovery_cached_response(
+            self.query, cache_region=cache, redis_client=redis, solve_fn=solve
+        )
+
+        self.assertEqual(redis.calls, [])
+        solve.assert_not_called()
+        self.assertEqual(result["diagnostics"]["solver"], "cpsat")
+        self.assertEqual(result["solver"], "cpsat")
+        self.assertEqual(result["diagnostics"]["cacheStatus"], "hit")
+        self.assertTrue(result["diagnostics"]["appCacheHit"])
+        self.assertEqual(result["diagnostics"]["lockWaitMs"], 0.0)
+
+    def test_miss_uses_production_args_and_global_serialization(self):
+        cache = FakeCache([None, None])
+        lock = FakeLock()
+        redis = FakeRedis(lock)
+        solve = Mock(return_value=response())
+
+        result = service.build_discovery_cached_response(
+            self.query, cache_region=cache, redis_client=redis, solve_fn=solve
+        )
+
+        self.assertEqual(
+            redis.calls,
+            [
+                (
+                    service.CPSAT_SOLVE_LOCK_KEY,
+                    {
+                        "timeout": service.CPSAT_SOLVE_LOCK_TIMEOUT_SECONDS,
+                        "blocking_timeout": service.CPSAT_SOLVE_LOCK_BLOCKING_TIMEOUT_SECONDS,
+                        "thread_local": False,
+                    },
+                )
+            ],
+        )
+        args = solve.call_args.args[1]
+        self.assertEqual(args.workers, 2)
+        self.assertEqual(args.time_limit_seconds, 3.2)
+        self.assertEqual(lock.acquire_calls, [{"blocking": True}])
+        self.assertTrue(lock.released)
+        self.assertEqual(result["cache"]["status"], "miss")
+        self.assertEqual(result["solverVersion"], service.CPSAT_SOLVER_VERSION)
+        self.assertTrue(next(iter(cache.stored)).startswith(service.CPSAT_CACHE_PREFIX))
+
+    def test_solve_lock_is_renewed_past_its_initial_expiry(self):
+        lock = FakeLock()
+
+        def slow_solve(query, args):
+            sleep(0.08)
+            return response()
+
+        result = service.build_discovery_cached_response(
+            self.query,
+            cache_region=FakeCache([None, None]),
+            redis_client=FakeRedis(lock),
+            solve_fn=slow_solve,
+            lock_timeout_seconds=0.03,
+            lock_renewal_interval_seconds=0.01,
+        )
+
+        self.assertEqual(result["status"], "complete")
+        self.assertGreaterEqual(len(lock.extend_calls), 2)
+        self.assertTrue(lock.released)
+
+    def test_expiring_lock_keeps_long_solves_serialized(self):
+        redis = ExpiringFakeRedis()
+        active = 0
+        maximum_active = 0
+        counter_lock = Lock()
+
+        def slow_solve(query, args):
+            nonlocal active, maximum_active
+            with counter_lock:
+                active += 1
+                maximum_active = max(maximum_active, active)
+            sleep(0.08)
+            with counter_lock:
+                active -= 1
+            return response()
+
+        def run(query):
+            return service.build_discovery_cached_response(
+                query,
+                cache_region=FakeCache([None, None]),
+                redis_client=redis,
+                solve_fn=slow_solve,
+                lock_blocking_timeout_seconds=0.3,
+                lock_timeout_seconds=0.03,
+                lock_renewal_interval_seconds=0.01,
+            )
+
+        queries = [
+            self.query,
+            BuildDiscoveryQuery(class_name="Cra", elements=("chance",)),
+        ]
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(run, queries))
+
+        self.assertEqual(maximum_active, 1)
+        self.assertEqual([result["status"] for result in results], ["complete"] * 2)
+
+    def test_renewal_failure_rejects_result_and_joins_before_release(self):
+        events = []
+
+        class FailingRenewalLock(FakeLock):
+            def extend(self, seconds):
+                events.append("renew-failed")
+                raise LockError("expired")
+
+            def release(self):
+                events.append("release")
+                raise LockError("not owned")
+
+        cache = FakeCache([None, None])
+        with self.assertRaises(service.BuildDiscoverySolveLockLost):
+            service.build_discovery_cached_response(
+                self.query,
+                cache_region=cache,
+                redis_client=FakeRedis(FailingRenewalLock()),
+                solve_fn=lambda query, args: (sleep(0.04), response())[1],
+                lock_timeout_seconds=0.03,
+                lock_renewal_interval_seconds=0.01,
+            )
+
+        self.assertEqual(events, ["renew-failed", "release"])
+        self.assertEqual(cache.stored, {})
+
+    def test_recheck_after_lock_deduplicates(self):
+        cached = response()
+        cache = FakeCache([None, cached])
+        lock = FakeLock()
+        solve = Mock()
+
+        with patch.object(service, "monotonic", side_effect=[10.0, 10.125]):
+            result = service.build_discovery_cached_response(
+                self.query,
+                cache_region=cache,
+                redis_client=FakeRedis(lock),
+                solve_fn=solve,
+            )
+
+        solve.assert_not_called()
+        self.assertEqual(len(cache.get_keys), 2)
+        self.assertEqual(result["cache"]["status"], "deduplicated")
+        self.assertTrue(result["diagnostics"]["solveLockAcquired"])
+        self.assertEqual(result["diagnostics"]["lockWaitMs"], 125.0)
+        self.assertEqual(result["diagnostics"]["elapsedMs"], 12.0)
+        self.assertTrue(lock.released)
+
+    def test_lost_lock_ownership_does_not_mask_completed_solve(self):
+        result = service.build_discovery_cached_response(
+            self.query,
+            cache_region=FakeCache([None, None]),
+            redis_client=FakeRedis(LostOwnershipLock()),
+            solve_fn=Mock(return_value=response()),
+        )
+
+        self.assertEqual(result["status"], "complete")
+
+    def test_response_provenance_and_target_metadata_are_preserved(self):
+        solved = response()
+        solved.update(
+            {
+                "cacheKey": "prototype-key",
+                "targets": {"ap": 11, "mp": 6, "range": 3},
+            }
+        )
+
+        result = service.build_discovery_cached_response(
+            self.query,
+            cache_region=FakeCache([None, None]),
+            redis_client=FakeRedis(),
+            solve_fn=Mock(return_value=solved),
+        )
+
+        self.assertEqual(result["datasetVersion"], "dataset-v1")
+        self.assertTrue(result["cacheKey"].startswith(service.CPSAT_CACHE_PREFIX))
+        self.assertEqual(result["targets"], {"ap": 11, "mp": 6, "range": 3})
+
+    def test_lock_acquisition_failure_is_explicit_and_bounded(self):
+        redis = FakeRedis(FakeLock(acquired=False))
+        with patch.object(service, "monotonic", side_effect=[2.0, 8.0]):
+            with self.assertRaisesRegex(
+                service.BuildDiscoverySolveLockTimeout, "6s"
+            ) as raised:
+                service.build_discovery_cached_response(
+                    self.query,
+                    cache_region=FakeCache([None]),
+                    redis_client=redis,
+                    solve_fn=Mock(),
+                )
+
+        self.assertEqual(raised.exception.lock_wait_ms, 6000.0)
+
+    def test_sync_lock_acquisition_fails_within_250ms_policy(self):
+        redis = FakeRedis(FakeLock(acquired=False))
+        with self.assertRaises(service.BuildDiscoverySolveLockTimeout):
+            service.build_discovery_cached_response(
+                self.query,
+                cache_region=FakeCache([None]),
+                redis_client=redis,
+                solve_fn=Mock(),
+                lock_blocking_timeout_seconds=(
+                    service.CPSAT_SYNC_SOLVE_LOCK_BLOCKING_TIMEOUT_SECONDS
+                ),
+            )
+
+        self.assertEqual(
+            redis.calls[0][1]["blocking_timeout"],
+            service.CPSAT_SYNC_SOLVE_LOCK_BLOCKING_TIMEOUT_SECONDS,
+        )
+        self.assertLess(redis.calls[0][1]["blocking_timeout"], 0.25)
+
+    def test_concurrent_misses_never_solve_in_parallel(self):
+        redis = SharedFakeRedis()
+        active = 0
+        maximum_active = 0
+        counter_lock = Lock()
+
+        def solve(query, args):
+            nonlocal active, maximum_active
+            with counter_lock:
+                active += 1
+                maximum_active = max(maximum_active, active)
+            sleep(0.05)
+            with counter_lock:
+                active -= 1
+            return response()
+
+        def run(query):
+            return service.build_discovery_cached_response(
+                query,
+                cache_region=FakeCache([None, None]),
+                redis_client=redis,
+                solve_fn=solve,
+            )
+
+        queries = [
+            self.query,
+            BuildDiscoveryQuery(class_name="Cra", elements=("chance",)),
+        ]
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(run, queries))
+
+        self.assertEqual(maximum_active, 1)
+        self.assertEqual([result["status"] for result in results], ["complete"] * 2)
+
+    def test_cache_key_is_solver_dataset_and_query_specific(self):
+        first = service.build_discovery_app_cache_key(self.query, "dataset-v1")
+        other_dataset = service.build_discovery_app_cache_key(self.query, "dataset-v2")
+        other_query = service.build_discovery_app_cache_key(
+            BuildDiscoveryQuery(class_name="Cra", elements=("strength",)), "dataset-v1"
+        )
+        self.assertNotEqual(first, other_dataset)
+        self.assertNotEqual(first, other_query)
+        self.assertTrue(first.startswith("build_discovery_response:cpsat:"))
+        self.assertFalse(
+            first.startswith("build_discovery_response:build-discovery-prototype")
+        )
+
+
+class ProductionDelegationTest(unittest.TestCase):
+    def test_product_input_maps_to_query_without_public_solver_tuning(self):
+        graphql = importlib.import_module("app.build_discovery_graphql")
+        input_value = Mock(
+            class_name="Iop",
+            level=200,
+            element="strength",
+            ap_target=11,
+            mp_target=6,
+            range_target=None,
+            damage_survivability_preset=3,
+            budget_tier=2,
+            exo_policy="allow",
+            weapon_policy="stat_stick_allowed",
+            locked_item_ids=[],
+            avoided_item_ids=[],
+            result_limit=3,
+            max_shared_items=service.DEFAULT_MAX_SHARED_ITEMS,
+        )
+
+        query = graphql.build_discovery_query_from_input(input_value)
+
+        self.assertEqual(query.elements, ("strength",))
+        self.assertEqual(query.mode, "pvm")
+        self.assertEqual(query.limit, 3)
+        self.assertEqual(query.max_shared_items, service.DEFAULT_MAX_SHARED_ITEMS)
+
+    def test_product_input_bounds_locked_and_avoided_item_controls(self):
+        graphql = importlib.import_module("app.build_discovery_graphql")
+        input_value = Mock(
+            class_name="Iop",
+            level=200,
+            element="strength",
+            ap_target=11,
+            mp_target=6,
+            range_target=None,
+            damage_survivability_preset=3,
+            budget_tier=2,
+            exo_policy="allow",
+            weapon_policy="stat_stick_allowed",
+            locked_item_ids=[],
+            avoided_item_ids=[],
+            result_limit=3,
+            max_shared_items=service.DEFAULT_MAX_SHARED_ITEMS,
+        )
+
+        for attribute, public_name in (
+            ("locked_item_ids", "lockedItemIds"),
+            ("avoided_item_ids", "avoidedItemIds"),
+        ):
+            with self.subTest(attribute=attribute):
+                setattr(
+                    input_value,
+                    attribute,
+                    [
+                        str(index)
+                        for index in range(graphql.MAX_ITEM_CONTROLS + 1)
+                    ],
+                )
+                with self.assertRaisesRegex(
+                    GraphQLError,
+                    f"{public_name} cannot contain more than "
+                    f"{graphql.MAX_ITEM_CONTROLS} items",
+                ):
+                    graphql.build_discovery_query_from_input(input_value)
+                setattr(input_value, attribute, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/scripts/test_build_discovery_service.py
+++ b/server/scripts/test_build_discovery_service.py
@@ -216,7 +216,7 @@ class BuildDiscoveryServiceTest(unittest.TestCase):
         )
         args = solve.call_args.args[1]
         self.assertEqual(args.workers, 2)
-        self.assertEqual(args.time_limit_seconds, 3.2)
+        self.assertEqual(args.time_limit_seconds, 6.0)
         self.assertEqual(lock.acquire_calls, [{"blocking": True}])
         self.assertTrue(lock.released)
         self.assertEqual(result["cache"]["status"], "miss")


### PR DESCRIPTION
## Summary

Adds the typed synchronous GraphQL contract, application cache and global solve-capacity lock, signed candidate promotion, and durable generated-build provenance through `GenerationRequest`.

## Why

The closed alpha favors a simple synchronous request even though quality-first cold misses may take roughly 12-14 seconds. The API bounds public controls, deduplicates concurrent solves, protects the 2-vCPU server with one global solve lock, and lets authenticated beta users promote only server-signed candidates.

## Review tour

1. GenerationRequest model and migration `395c1a102439`.
2. `build_discovery_service.py`: cache identity, compact payload, renewable lock, and six-second-per-lane release budget.
3. `build_discovery_graphql.py`: typed schema, limits, rate limiting, and normalization.
4. `build_discovery_promotion.py`: signed one-hour candidate token and server-authoritative promotion.
5. Schema/loaders/model integration.
6. Service and GraphQL tests.

## Contract highlights

- `buildDiscovery(input: BuildDiscoveryInput!): BuildDiscoveryResult!`
- No polling jobs or public solver-tuning controls.
- Search requests are cached but not persisted as database rows.
- `GenerationRequest` is created only when a generated candidate is promoted to a custom set; deleting that set cascades to its provenance row.
- Result limit 1-5; lock/avoid lists capped at 50; shared-item limit bounded 0-16.
- `rangeTarget: null` preserves any-range semantics.
- Cache keys include separate solver and deterministic dataset versions.

## Validation

- Integrated Build Discovery server suite passed in Docker.
- GraphQL service test guards the six-second release budget.
- Alembic head: `395c1a102439`.

## Stack

#499 -> #500 -> #501 -> **#502** -> #503 -> #504 -> #505 -> #506