### PR TITLE
Require authentication for Build Discovery gate

### DIFF
--- a/client/common/statsig.test.tsx
+++ b/client/common/statsig.test.tsx
@@ -81,10 +81,31 @@ describe('Build Discovery Statsig boundary', () => {
     expect(checkGate).not.toHaveBeenCalled();
   });
 
+  it('keeps the gate disabled for anonymous users', () => {
+    checkGate.mockReturnValue(true);
+    render(
+      <DofusLabStatsigProvider>
+        <GateProbe />
+      </DofusLabStatsigProvider>,
+    );
+
+    expect(screen.getByText('false:false')).toBeTruthy();
+    expect(checkGate).not.toHaveBeenCalled();
+  });
+
   it.each([
     [false, 'false:false'],
     [true, 'false:true'],
   ])('reports a ready gate result of %s', (enabled, expected) => {
+    const id = '3ccf19fd-e9cc-4a78-b80d-c9c46feee1b8';
+    apolloState = {
+      loading: false,
+      data: { currentUser: { id, username: 'PrivateUser' } },
+    };
+    statsigUser = {
+      userID: id,
+      privateAttributes: { username: 'PrivateUser' },
+    };
     checkGate.mockReturnValue(enabled);
     render(
       <DofusLabStatsigProvider>

--- a/client/common/statsig.tsx
+++ b/client/common/statsig.tsx
@@ -19,11 +19,13 @@ import { currentUser as CurrentUserQuery } from 'graphql/queries/__generated__/c
 export const BUILD_DISCOVERY_GATE = 'build_generator_beta';
 
 interface StatsigState {
+  authenticated: boolean;
   configured: boolean;
   identityReady: boolean;
 }
 
 const StatsigStateContext = createContext<StatsigState>({
+  authenticated: false,
   configured: false,
   identityReady: true,
 });
@@ -43,8 +45,8 @@ const StatsigIdentity = ({ children }: Props) => {
   const identityReady =
     !loading && user.userID === userId && statsigUsername === username;
   const statsigState = useMemo(
-    () => ({ configured: true, identityReady }),
-    [identityReady],
+    () => ({ authenticated: Boolean(userId), configured: true, identityReady }),
+    [identityReady, userId],
   );
 
   useEffect(() => {
@@ -99,7 +101,8 @@ export const DofusLabStatsigProvider = ({ children }: Props) => {
 };
 
 export const useBuildDiscoveryGate = () => {
-  const { configured, identityReady } = useContext(StatsigStateContext);
+  const { authenticated, configured, identityReady } =
+    useContext(StatsigStateContext);
   const { checkGate, isLoading } = useStatsigClient();
 
   if (!configured) {
@@ -109,7 +112,7 @@ export const useBuildDiscoveryGate = () => {
   const loading = !identityReady || isLoading;
 
   return {
-    enabled: !loading && checkGate(BUILD_DISCOVERY_GATE),
+    enabled: !loading && authenticated && checkGate(BUILD_DISCOVERY_GATE),
     loading,
   };
 };


### PR DESCRIPTION
## Summary
- require an authenticated DofusLab identity before evaluating the Build Discovery Statsig gate
- keep anonymous users fail-closed even if Statsig would enable an anonymous identity
- add regression coverage for anonymous and authenticated gate behavior

## Verification
- 68 frontend tests pass
- TypeScript and focused ESLint checks pass