### PR TITLE
Add frontend parity tests and authenticated beta gating

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ node_modules/
 client/node_modules/
 client/__generated__/
 client/graphql/*/__generated__/
+client/next-env.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,7 +63,15 @@ module.exports = {
     ],
     'import/no-extraneous-dependencies': [
       2,
-      { devDependencies: ['**/test.tsx', '**/test.ts'] },
+      {
+        devDependencies: [
+          '**/test.tsx',
+          '**/test.ts',
+          '**/*.test.tsx',
+          '**/*.test.ts',
+          '**/vitest.config.ts',
+        ],
+      },
     ],
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-unused-vars': [

--- a/client/common/conditionEvaluator.ts
+++ b/client/common/conditionEvaluator.ts
@@ -1,0 +1,88 @@
+import { TCondition, TConditionObj } from './types';
+
+export const CONDITION_STAT_TO_STAT_NAME: Record<string, string> = {
+  AP: 'AP',
+  MP: 'MP',
+  RANGE: 'Range',
+  VITALITY: 'Vitality',
+  WISDOM: 'Wisdom',
+  STRENGTH: 'Strength',
+  INTELLIGENCE: 'Intelligence',
+  CHANCE: 'Chance',
+  AGILITY: 'Agility',
+  CRITICAL: 'Critical',
+  DODGE: 'Dodge',
+  LOCK: 'Lock',
+  POWER: 'Power',
+  DAMAGE: 'Damage',
+  EARTH_DAMAGE: 'Earth Damage',
+  NEUTRAL_DAMAGE: 'Neutral Damage',
+  FIRE_DAMAGE: 'Fire Damage',
+  WATER_DAMAGE: 'Water Damage',
+  AIR_DAMAGE: 'Air Damage',
+};
+
+export const isLeafCondition = (
+  conditionObj: TConditionObj,
+): conditionObj is TCondition => {
+  const condition = conditionObj as TCondition;
+  return !!(
+    condition.operator &&
+    condition.stat &&
+    condition.value !== null &&
+    condition.value !== undefined
+  );
+};
+
+export const traverseConditions = (
+  conditionObj: TConditionObj,
+  evaluateLeaf: (condition: TCondition) => boolean,
+): boolean => {
+  if (!conditionObj || Object.keys(conditionObj).length === 0) {
+    return true;
+  }
+  if (isLeafCondition(conditionObj)) {
+    return evaluateLeaf(conditionObj);
+  }
+  if (conditionObj.and?.length) {
+    return conditionObj.and.every((child) =>
+      traverseConditions(child, evaluateLeaf),
+    );
+  }
+  if (conditionObj.or?.length) {
+    return conditionObj.or.some((child) =>
+      traverseConditions(child, evaluateLeaf),
+    );
+  }
+  return true;
+};
+
+export const evaluateConditions = (
+  conditionObj: TConditionObj,
+  resolveValue: (condition: TCondition) => number,
+) =>
+  traverseConditions(conditionObj, (condition) => {
+    const value = resolveValue(condition);
+
+    if (condition.operator === '<') {
+      return value < condition.value;
+    }
+    if (condition.operator === '>') {
+      return value > condition.value;
+    }
+    return true;
+  });
+
+export const evaluateFixtureCondition = (
+  conditionObj: TConditionObj,
+  stats: Record<string, number>,
+  setCounts: Record<string, number>,
+) =>
+  evaluateConditions(conditionObj, (condition) =>
+    condition.stat === 'SET_BONUS'
+      ? Object.values(setCounts).reduce(
+          (total, count) => total + Math.max(count - 1, 0),
+          0,
+        )
+      : stats[CONDITION_STAT_TO_STAT_NAME[condition.stat] || ''] || 0,
+  );

--- a/client/common/damageCalculator.ts
+++ b/client/common/damageCalculator.ts
@@ -1,0 +1,55 @@
+import { Stat } from '__generated__/globalTypes';
+
+import { CalcDamageInput, StatsFromCustomSet } from './types';
+
+export interface DamageStatTypes {
+  multiplier: Stat;
+  damage: Stat;
+}
+
+const getStat = (stats: StatsFromCustomSet | null, stat: Stat) =>
+  stats?.[stat] || 0;
+
+export const calculateDamage = (
+  baseDamage: number,
+  statTypes: DamageStatTypes,
+  stats: StatsFromCustomSet | null,
+  damageTypeInput: CalcDamageInput,
+  weaponSkillPower = 0,
+  critBonusDamage = 0,
+) => {
+  let multiplierValue =
+    getStat(stats, statTypes.multiplier) + getStat(stats, Stat.POWER);
+  let damageValue =
+    getStat(stats, statTypes.damage) + getStat(stats, Stat.DAMAGE);
+
+  if (damageTypeInput.isTrap) {
+    multiplierValue += getStat(stats, Stat.TRAP_POWER);
+    damageValue += getStat(stats, Stat.TRAP_DAMAGE);
+  }
+  if (damageTypeInput.isCrit) {
+    damageValue += getStat(stats, Stat.CRITICAL_DAMAGE) + critBonusDamage;
+  }
+  if (damageTypeInput.isWeapon) {
+    multiplierValue += weaponSkillPower;
+  }
+
+  const calculatedDamage = Math.floor(
+    baseDamage * (1 + multiplierValue / 100) + damageValue,
+  );
+  let finalDamageMod = 1 + getStat(stats, Stat.PCT_FINAL_DAMAGE) / 100;
+  finalDamageMod *= damageTypeInput.isWeapon
+    ? 1 + getStat(stats, Stat.PCT_WEAPON_DAMAGE) / 100
+    : 1 + getStat(stats, Stat.PCT_SPELL_DAMAGE) / 100;
+
+  return {
+    melee: Math.floor(
+      calculatedDamage *
+        (finalDamageMod * (1 + getStat(stats, Stat.PCT_MELEE_DAMAGE) / 100)),
+    ),
+    ranged: Math.floor(
+      calculatedDamage *
+        (finalDamageMod * (1 + getStat(stats, Stat.PCT_RANGED_DAMAGE) / 100)),
+    ),
+  };
+};

--- a/client/common/parityFixtures.test.ts
+++ b/client/common/parityFixtures.test.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+
+import { Stat } from '__generated__/globalTypes';
+import { describe, expect, it } from 'vitest';
+
+import { evaluateFixtureCondition } from './conditionEvaluator';
+import { calculateDamage, DamageStatTypes } from './damageCalculator';
+import { TConditionObj } from './types';
+
+const fixture = (name: string) =>
+  JSON.parse(
+    fs.readFileSync(
+      new URL(`../../server/oneoff/fixtures/parity/${name}`, import.meta.url),
+      'utf8',
+    ),
+  );
+
+const damageFixtures = fixture('damage_cases.json') as {
+  resistanceDecision: string;
+  cases: Array<{
+    name: string;
+    baseDamage: number;
+    element: keyof typeof ELEMENT_STATS;
+    stats: Record<string, number>;
+    flags: {
+      isCrit?: boolean;
+      isTrap?: boolean;
+      isWeapon?: boolean;
+      weaponSkillPower?: number;
+      critBonusDamage?: number;
+    };
+    expected: { melee: number; ranged: number };
+  }>;
+};
+
+const conditionFixtures = fixture('condition_cases.json') as {
+  cases: Array<{
+    name: string;
+    condition: TConditionObj;
+    stats: Record<string, number>;
+    setCounts: Record<string, number>;
+    expected: boolean;
+  }>;
+};
+
+const ELEMENT_STATS: Record<string, DamageStatTypes> = {
+  neutral: { multiplier: Stat.STRENGTH, damage: Stat.NEUTRAL_DAMAGE },
+  earth: { multiplier: Stat.STRENGTH, damage: Stat.EARTH_DAMAGE },
+  fire: { multiplier: Stat.INTELLIGENCE, damage: Stat.FIRE_DAMAGE },
+  water: { multiplier: Stat.CHANCE, damage: Stat.WATER_DAMAGE },
+  air: { multiplier: Stat.AGILITY, damage: Stat.AIR_DAMAGE },
+};
+
+const DAMAGE_STAT_NAMES: Record<string, Stat> = {
+  Strength: Stat.STRENGTH,
+  Intelligence: Stat.INTELLIGENCE,
+  Chance: Stat.CHANCE,
+  Agility: Stat.AGILITY,
+  Power: Stat.POWER,
+  'Neutral Damage': Stat.NEUTRAL_DAMAGE,
+  'Earth Damage': Stat.EARTH_DAMAGE,
+  'Fire Damage': Stat.FIRE_DAMAGE,
+  'Water Damage': Stat.WATER_DAMAGE,
+  'Air Damage': Stat.AIR_DAMAGE,
+  Damage: Stat.DAMAGE,
+  'Critical Damage': Stat.CRITICAL_DAMAGE,
+  'Trap Power': Stat.TRAP_POWER,
+  'Trap Damage': Stat.TRAP_DAMAGE,
+  '% Final Damage': Stat.PCT_FINAL_DAMAGE,
+  '% Weapon Damage': Stat.PCT_WEAPON_DAMAGE,
+  '% Spell Damage': Stat.PCT_SPELL_DAMAGE,
+  '% Melee Damage': Stat.PCT_MELEE_DAMAGE,
+  '% Ranged Damage': Stat.PCT_RANGED_DAMAGE,
+};
+
+describe('shared damage parity fixtures', () => {
+  it('documents resistance as outside the outgoing solver contract', () => {
+    expect(damageFixtures.resistanceDecision).toContain(
+      'outside the backend solver contract',
+    );
+  });
+
+  it.each(damageFixtures.cases)('$name', (testCase) => {
+    const stats = Object.fromEntries(
+      Object.entries(testCase.stats).map(([name, value]) => [
+        DAMAGE_STAT_NAMES[name],
+        value,
+      ]),
+    );
+    const result = calculateDamage(
+      testCase.baseDamage,
+      ELEMENT_STATS[testCase.element],
+      stats,
+      {
+        isCrit: testCase.flags.isCrit || false,
+        isTrap: testCase.flags.isTrap || false,
+        isWeapon: testCase.flags.isWeapon || false,
+      },
+      testCase.flags.weaponSkillPower,
+      testCase.flags.critBonusDamage,
+    );
+
+    expect(result).toEqual(testCase.expected);
+  });
+});
+
+describe('shared condition parity fixtures', () => {
+  it.each(conditionFixtures.cases)('$name', (testCase) => {
+    expect(
+      evaluateFixtureCondition(
+        testCase.condition,
+        testCase.stats,
+        testCase.setCounts,
+      ),
+    ).toBe(testCase.expected);
+  });
+});

--- a/client/common/statsig.test.tsx
+++ b/client/common/statsig.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BUILD_DISCOVERY_GATE,
+  DofusLabStatsigProvider,
+  useBuildDiscoveryGate,
+} from './statsig';
+
+type ApolloState = {
+  data?: { currentUser: { id: string; username: string } | null };
+  loading: boolean;
+};
+
+let apolloState: ApolloState;
+let statsigUser: {
+  userID?: string;
+  privateAttributes?: { username?: string };
+};
+let statsigLoading: boolean;
+const checkGate = vi.fn();
+const updateUserAsync = vi.fn(() => Promise.resolve());
+
+vi.mock('@apollo/client', () => ({
+  useQuery: () => apolloState,
+}));
+
+vi.mock('@statsig/react-bindings', () => ({
+  LogLevel: { Debug: 'debug', Warn: 'warn' },
+  StatsigProvider: ({ children }: { children: React.ReactNode }) => children,
+  useStatsigClient: () => ({ checkGate, isLoading: statsigLoading }),
+  useStatsigUser: () => ({ user: statsigUser, updateUserAsync }),
+}));
+
+vi.mock('graphql/queries/currentUser.graphql', () => ({ default: {} }));
+
+const GateProbe = () => {
+  const gate = useBuildDiscoveryGate();
+  return <div>{`${gate.loading}:${gate.enabled}`}</div>;
+};
+
+describe('Build Discovery Statsig boundary', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_STATSIG_CLIENT_KEY = 'client-test-key';
+    apolloState = { loading: false, data: { currentUser: null } };
+    statsigUser = {};
+    statsigLoading = false;
+    checkGate.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete process.env.NEXT_PUBLIC_STATSIG_CLIENT_KEY;
+  });
+
+  it('fails closed when the client key is missing', () => {
+    delete process.env.NEXT_PUBLIC_STATSIG_CLIENT_KEY;
+    render(
+      <DofusLabStatsigProvider>
+        <GateProbe />
+      </DofusLabStatsigProvider>,
+    );
+
+    expect(screen.getByText('false:false')).toBeTruthy();
+    expect(checkGate).not.toHaveBeenCalled();
+  });
+
+  it('stays disabled while Apollo identity or Statsig is loading', () => {
+    apolloState = { loading: true };
+    statsigLoading = true;
+    render(
+      <DofusLabStatsigProvider>
+        <GateProbe />
+      </DofusLabStatsigProvider>,
+    );
+
+    expect(screen.getByText('true:false')).toBeTruthy();
+    expect(checkGate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [false, 'false:false'],
+    [true, 'false:true'],
+  ])('reports a ready gate result of %s', (enabled, expected) => {
+    checkGate.mockReturnValue(enabled);
+    render(
+      <DofusLabStatsigProvider>
+        <GateProbe />
+      </DofusLabStatsigProvider>,
+    );
+
+    expect(screen.getByText(expected)).toBeTruthy();
+    expect(checkGate).toHaveBeenCalledWith(BUILD_DISCOVERY_GATE);
+  });
+
+  it('updates authenticated identity with UUID and private username', async () => {
+    const id = '3ccf19fd-e9cc-4a78-b80d-c9c46feee1b8';
+    apolloState = {
+      loading: false,
+      data: { currentUser: { id, username: 'PrivateUser' } },
+    };
+    render(
+      <DofusLabStatsigProvider>
+        <GateProbe />
+      </DofusLabStatsigProvider>,
+    );
+
+    await waitFor(() =>
+      expect(updateUserAsync).toHaveBeenCalledWith({
+        userID: id,
+        privateAttributes: { username: 'PrivateUser' },
+      }),
+    );
+    expect(screen.getByText('true:false')).toBeTruthy();
+  });
+});

--- a/client/common/statsig.test.tsx
+++ b/client/common/statsig.test.tsx
@@ -81,10 +81,31 @@ describe('Build Discovery Statsig boundary', () => {
     expect(checkGate).not.toHaveBeenCalled();
   });
 
+  it('keeps the gate disabled for anonymous users', () => {
+    checkGate.mockReturnValue(true);
+    render(
+      <DofusLabStatsigProvider>
+        <GateProbe />
+      </DofusLabStatsigProvider>,
+    );
+
+    expect(screen.getByText('false:false')).toBeTruthy();
+    expect(checkGate).not.toHaveBeenCalled();
+  });
+
   it.each([
     [false, 'false:false'],
     [true, 'false:true'],
   ])('reports a ready gate result of %s', (enabled, expected) => {
+    const id = '3ccf19fd-e9cc-4a78-b80d-c9c46feee1b8';
+    apolloState = {
+      loading: false,
+      data: { currentUser: { id, username: 'PrivateUser' } },
+    };
+    statsigUser = {
+      userID: id,
+      privateAttributes: { username: 'PrivateUser' },
+    };
     checkGate.mockReturnValue(enabled);
     render(
       <DofusLabStatsigProvider>

--- a/client/common/statsig.tsx
+++ b/client/common/statsig.tsx
@@ -19,11 +19,13 @@ import { currentUser as CurrentUserQuery } from 'graphql/queries/__generated__/c
 export const BUILD_DISCOVERY_GATE = 'build_generator_beta';
 
 interface StatsigState {
+  authenticated: boolean;
   configured: boolean;
   identityReady: boolean;
 }
 
 const StatsigStateContext = createContext<StatsigState>({
+  authenticated: false,
   configured: false,
   identityReady: true,
 });
@@ -43,8 +45,8 @@ const StatsigIdentity = ({ children }: Props) => {
   const identityReady =
     !loading && user.userID === userId && statsigUsername === username;
   const statsigState = useMemo(
-    () => ({ configured: true, identityReady }),
-    [identityReady],
+    () => ({ authenticated: Boolean(userId), configured: true, identityReady }),
+    [identityReady, userId],
   );
 
   useEffect(() => {
@@ -99,7 +101,8 @@ export const DofusLabStatsigProvider = ({ children }: Props) => {
 };
 
 export const useBuildDiscoveryGate = () => {
-  const { configured, identityReady } = useContext(StatsigStateContext);
+  const { authenticated, configured, identityReady } =
+    useContext(StatsigStateContext);
   const { checkGate, isLoading } = useStatsigClient();
 
   if (!configured) {
@@ -109,7 +112,7 @@ export const useBuildDiscoveryGate = () => {
   const loading = !identityReady || isLoading;
 
   return {
-    enabled: !loading && checkGate(BUILD_DISCOVERY_GATE),
+    enabled: !loading && authenticated && checkGate(BUILD_DISCOVERY_GATE),
     loading,
   };
 };

--- a/client/common/utils.tsx
+++ b/client/common/utils.tsx
@@ -81,8 +81,6 @@ import {
   ExoStatLine,
   CalcDamageInput,
   TSimpleEffect,
-  TCondition,
-  TConditionObj,
   StatCalculator,
   BaseStatKey,
   WeaponEffect,
@@ -106,6 +104,8 @@ import {
   EquippedItemSlot,
 } from './type-aliases';
 import { prependDe } from './i18n-utils';
+import { calculateDamage } from './damageCalculator';
+import { evaluateConditions } from './conditionEvaluator';
 
 export const getImageUrl = (suffix: string) =>
   suffix.startsWith('https://')
@@ -873,51 +873,17 @@ export const calcDamage = (
   stats: StatsFromCustomSet | null,
   damageTypeInput: CalcDamageInput,
   weaponSkillPower?: number,
+  critBonusDamage?: number,
 ) => {
   const statTypes = getStats(effectType, stats);
-  const { multiplier: multiplierType, damage: damageType } = statTypes;
-  let multiplierValue =
-    getStatWithDefault(stats, multiplierType) +
-    getStatWithDefault(stats, Stat.POWER);
-  let damageValue =
-    getStatWithDefault(stats, damageType) +
-    getStatWithDefault(stats, Stat.DAMAGE);
-  if (damageTypeInput.isTrap) {
-    multiplierValue += getStatWithDefault(stats, Stat.TRAP_POWER);
-    damageValue += getStatWithDefault(stats, Stat.TRAP_DAMAGE);
-  }
-  if (damageTypeInput.isCrit) {
-    damageValue += getStatWithDefault(stats, Stat.CRITICAL_DAMAGE);
-  }
-  if (damageTypeInput.isWeapon) {
-    multiplierValue += weaponSkillPower || 0;
-  }
-  const calculatedDamage = Math.floor(
-    baseDamage * (1 + multiplierValue / 100) + damageValue,
+  return calculateDamage(
+    baseDamage,
+    statTypes,
+    stats,
+    damageTypeInput,
+    weaponSkillPower,
+    critBonusDamage,
   );
-
-  let finalDamageMod =
-    1 + getStatWithDefault(stats, Stat.PCT_FINAL_DAMAGE) / 100;
-  if (damageTypeInput.isWeapon) {
-    finalDamageMod *=
-      1 + getStatWithDefault(stats, Stat.PCT_WEAPON_DAMAGE) / 100;
-  } else {
-    finalDamageMod *=
-      1 + getStatWithDefault(stats, Stat.PCT_SPELL_DAMAGE) / 100;
-  }
-
-  return {
-    melee: Math.floor(
-      calculatedDamage *
-        (finalDamageMod *
-          (1 + getStatWithDefault(stats, Stat.PCT_MELEE_DAMAGE) / 100)),
-    ),
-    ranged: Math.floor(
-      calculatedDamage *
-        (finalDamageMod *
-          (1 + getStatWithDefault(stats, Stat.PCT_RANGED_DAMAGE) / 100)),
-    ),
-  };
 };
 
 export const calcPushbackDamage = (
@@ -1248,76 +1214,9 @@ export const statCalculators: { [key: string]: StatCalculator } = {
     getStatWithDefault(statsFromCustomSet, Stat.STRENGTH) * 5,
 };
 
-function isLeafCondition(
-  conditionObj: TConditionObj,
-): conditionObj is TCondition {
-  return !!(
-    (conditionObj as TCondition).operator &&
-    (conditionObj as TCondition).stat &&
-    (conditionObj as TCondition).value
-  );
-}
-
 const getDefaultStatCalculator =
   (stat: Stat) => (statsFromCustomSet: StatsFromCustomSet) =>
     getStatWithDefault(statsFromCustomSet, stat);
-
-const evaluateLeafCondition = (
-  customSet: CustomSet,
-  statsFromCustomSet: StatsFromCustomSet,
-  condition: TCondition,
-) => {
-  if (condition.stat === 'SET_BONUS') {
-    const setBonuses = getBonusesFromCustomSet(customSet);
-    const numberBonuses = Object.values(setBonuses).reduce(
-      (acc, v) => acc + v.count - 1,
-      0,
-    );
-    if (condition.operator === '<') {
-      return numberBonuses < condition.value;
-    }
-    if (condition.operator === '>') {
-      return numberBonuses > condition.value;
-    }
-  } else {
-    const statCalculator =
-      statCalculators[condition.stat] ||
-      getDefaultStatCalculator(condition.stat);
-    const value = statCalculator(statsFromCustomSet, customSet);
-    if (condition.operator === '<') {
-      return value < condition.value;
-    }
-    if (condition.operator === '>') {
-      return value > condition.value;
-    }
-  }
-  // eslint-disable-next-line no-console
-  console.error('Unable to parse condition', condition);
-  return true;
-};
-
-const traverseConditions = (
-  customSet: CustomSet,
-  statsFromCustomSet: StatsFromCustomSet,
-  conditionsObj: TConditionObj,
-): boolean => {
-  if (isLeafCondition(conditionsObj)) {
-    return evaluateLeafCondition(customSet, statsFromCustomSet, conditionsObj);
-  }
-  if (conditionsObj.and) {
-    return conditionsObj.and.every((obj) =>
-      traverseConditions(customSet, statsFromCustomSet, obj),
-    );
-  }
-  if (conditionsObj.or) {
-    return conditionsObj.or.some((obj) =>
-      traverseConditions(customSet, statsFromCustomSet, obj),
-    );
-  }
-  // eslint-disable-next-line no-console
-  console.error('Unable to parse condition', conditionsObj);
-  return true;
-};
 
 export const checkConditions = (
   customSet: CustomSet | null,
@@ -1338,7 +1237,20 @@ export const checkConditions = (
     const parsed = JSON.parse(equippedItem.item.conditions);
     if (parsed && parsed.conditions && Object.keys(parsed.conditions).length) {
       const conditionsObj = parsed.conditions;
-      const pass = traverseConditions(customSet, customSetStats, conditionsObj);
+      const pass = evaluateConditions(conditionsObj, (condition) => {
+        if (condition.stat === 'SET_BONUS') {
+          const setBonuses = getBonusesFromCustomSet(customSet);
+          return Object.values(setBonuses).reduce(
+            (total, bonus) => total + bonus.count - 1,
+            0,
+          );
+        }
+
+        const statCalculator =
+          statCalculators[condition.stat] ||
+          getDefaultStatCalculator(condition.stat);
+        return statCalculator(customSetStats, customSet);
+      });
       if (!pass) {
         failingItems.push(equippedItem);
       }

--- a/client/components/common/BuildDiscoveryNavigation.test.tsx
+++ b/client/components/common/BuildDiscoveryNavigation.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BuildDiscoveryDesktopNavigation,
+  buildDiscoveryMobileMenuItem,
+} from './BuildDiscoveryNavigation';
+
+vi.mock('components/common/Tooltip', () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock('antd', () => ({
+  Button: ({
+    children,
+    href,
+    'aria-label': ariaLabel,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    'aria-label': string;
+  }) => (
+    <a href={href} aria-label={ariaLabel}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: () => <span data-testid="search-icon" />,
+}));
+vi.mock('@fortawesome/free-solid-svg-icons', () => ({ faSearch: {} }));
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+describe('Build Discovery navigation visibility', () => {
+  afterEach(cleanup);
+
+  it.each([false, true])('matches the desktop gate state %s', (enabled) => {
+    render(
+      <BuildDiscoveryDesktopNavigation
+        enabled={enabled}
+        label="Build Discovery"
+      />,
+    );
+    expect(screen.queryByLabelText('Build Discovery') !== null).toBe(enabled);
+  });
+
+  it.each([false, true])('matches the mobile gate state %s', (enabled) => {
+    const item = buildDiscoveryMobileMenuItem(enabled, 'Build Discovery', {});
+    render(item?.label || null);
+    expect(screen.queryByText('Build Discovery') !== null).toBe(enabled);
+    expect(item?.key).toBe(enabled ? 'build-discovery' : undefined);
+  });
+});

--- a/client/components/common/BuildDiscoveryNavigation.tsx
+++ b/client/components/common/BuildDiscoveryNavigation.tsx
@@ -1,0 +1,56 @@
+/** @jsxImportSource @emotion/react */
+
+import { Button } from 'antd';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Link from 'next/link';
+
+import Tooltip from 'components/common/Tooltip';
+
+interface NavigationProps {
+  enabled: boolean;
+  label: string;
+}
+
+export const BuildDiscoveryDesktopNavigation = ({
+  enabled,
+  label,
+}: NavigationProps) => {
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <Tooltip placement="bottom" title={label}>
+      <Button
+        aria-label={label}
+        href="/build-discovery"
+        css={{ marginLeft: 12 }}
+      >
+        <FontAwesomeIcon icon={faSearch} />
+      </Button>
+    </Tooltip>
+  );
+};
+
+export const buildDiscoveryMobileMenuItem = (
+  enabled: boolean,
+  label: string,
+  iconWrapper: Record<string, string | number>,
+) => {
+  if (!enabled) {
+    return null;
+  }
+
+  return {
+    key: 'build-discovery',
+    label: (
+      <Link href="/build-discovery" as="/build-discovery">
+        <span css={iconWrapper}>
+          <FontAwesomeIcon icon={faSearch} />
+        </span>
+        {label}
+      </Link>
+    ),
+  };
+};

--- a/client/components/desktop/Layout.tsx
+++ b/client/components/desktop/Layout.tsx
@@ -33,7 +33,6 @@ import {
   faKey,
   faKeyboard,
   faMugHot,
-  faSearch,
   faWrench,
 } from '@fortawesome/free-solid-svg-icons';
 import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons';
@@ -56,6 +55,7 @@ import { switchStyle } from 'common/mixins';
 import { ClassicContext, getImageUrl } from 'common/utils';
 import { DownOutlined } from '@ant-design/icons';
 import { Media } from 'components/common/Media';
+import { BuildDiscoveryDesktopNavigation } from '../common/BuildDiscoveryNavigation';
 
 const BuildList = dynamic(() => import('../common/BuildList'), { ssr: false });
 const SignUpModal = dynamic(() => import('../common/SignUpModal'), {
@@ -365,20 +365,10 @@ function Layout({ children, showSwitch }: LayoutProps) {
           </div>
           <div css={{ display: 'flex', alignItems: 'center' }}>
             {showSwitch && classicSwitch}
-            {buildDiscoveryEnabled && (
-              <Tooltip
-                placement="bottom"
-                title={t('BUILD_DISCOVERY', { ns: 'common' })}
-              >
-                <Button
-                  aria-label={t('BUILD_DISCOVERY', { ns: 'common' })}
-                  href="/build-discovery"
-                  css={{ marginLeft: 12 }}
-                >
-                  <FontAwesomeIcon icon={faSearch} />
-                </Button>
-              </Tooltip>
-            )}
+            <BuildDiscoveryDesktopNavigation
+              enabled={buildDiscoveryEnabled}
+              label={t('BUILD_DISCOVERY', { ns: 'common' })}
+            />
             {data?.currentUser ? (
               <div>
                 {langSelect}

--- a/client/components/mobile/Layout.tsx
+++ b/client/components/mobile/Layout.tsx
@@ -30,7 +30,6 @@ import {
   faUserPlus,
   faKey,
   faMugHot,
-  faSearch,
   faWrench,
 } from '@fortawesome/free-solid-svg-icons';
 import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons';
@@ -48,6 +47,7 @@ import {
   BUY_ME_COFFEE_LINK,
 } from 'common/constants';
 import { getImageUrl } from 'common/utils';
+import { buildDiscoveryMobileMenuItem } from '../common/BuildDiscoveryNavigation';
 
 const SignUpModal = dynamic(() => import('../common/SignUpModal'), {
   ssr: false,
@@ -188,18 +188,13 @@ function Layout({ children }: LayoutProps) {
   const menuItems: MenuItem[] = useMemo(() => {
     const items: MenuItem[] = [];
 
-    if (buildDiscoveryEnabled) {
-      items.push({
-        key: 'build-discovery',
-        label: (
-          <Link href="/build-discovery" as="/build-discovery">
-            <span css={iconWrapper}>
-              <FontAwesomeIcon icon={faSearch} />
-            </span>
-            {t('BUILD_DISCOVERY', { ns: 'common' })}
-          </Link>
-        ),
-      });
+    const buildDiscoveryItem = buildDiscoveryMobileMenuItem(
+      buildDiscoveryEnabled,
+      t('BUILD_DISCOVERY', { ns: 'common' }),
+      iconWrapper,
+    );
+    if (buildDiscoveryItem) {
+      items.push(buildDiscoveryItem);
     }
 
     items.push({

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,8 @@
     "dev-docker": "NODE_OPTIONS='--inspect=0.0.0.0:9229' yarn codegen && next dev",
     "build": "next build && tsc --project tsconfig.server.json",
     "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "type-check": "tsc",
     "generate": "graphql-codegen && npx prettier --write ./__generated__/globalTypes.ts && npx prettier --write ./graphql/**/__generated__/*.ts",
     "codegen": "yarn generate",
@@ -74,6 +76,8 @@
     "@graphql-codegen/add": "^6.0.0",
     "@graphql-codegen/near-operation-file-preset": "^3.1.0",
     "@parcel/watcher": "^2.5.1",
+    "@testing-library/dom": "10.4.0",
+    "@testing-library/react": "16.3.0",
     "@types/express": "^4.17.6",
     "@types/gtag.js": "^0.0.3",
     "@types/js-cookie": "^3.0.1",
@@ -87,10 +91,12 @@
     "cross-env": "^10.0.0",
     "graphql-codegen-apollo-next-ssr": "^1.7.4",
     "i18next-scanner": "^2.11.0",
+    "jsdom": "26.1.0",
     "nodemon": "^2.0.4",
     "sort-keys": "^4.0.0",
     "ts-node": "^8.10.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "3.2.4"
   },
   "lint-staged": {
     "*.tsx": [

--- a/client/tests/build-discovery-page.test.tsx
+++ b/client/tests/build-discovery-page.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import BuildDiscoveryPage from 'pages/build-discovery';
+
+let gate = { enabled: false, loading: false };
+
+vi.mock('common/statsig', () => ({
+  useBuildDiscoveryGate: () => gate,
+}));
+vi.mock('components/common/BuildDiscoveryPage', () => ({
+  default: () => <div>discovery-content</div>,
+}));
+vi.mock('components/common/CommonLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock('components/common/Media', () => ({ mediaStyles: '' }));
+vi.mock('common/i18n-utils', () => ({ DEFAULT_LANGUAGE: 'en' }));
+vi.mock('common/utils', () => ({ getTitle: (title: string) => title }));
+vi.mock('pages/_error', () => ({
+  default: ({ statusCode }: { statusCode: number }) => (
+    <div>{`error-${statusCode}`}</div>
+  ),
+}));
+vi.mock('next/head', () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock('next-i18next/serverSideTranslations', () => ({
+  serverSideTranslations: vi.fn(),
+}));
+
+describe('Build Discovery direct route', () => {
+  afterEach(cleanup);
+
+  it('renders nothing while the gate is loading', () => {
+    gate = { enabled: false, loading: true };
+    const { container } = render(<BuildDiscoveryPage />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('denies direct navigation when disabled', () => {
+    gate = { enabled: false, loading: false };
+    render(<BuildDiscoveryPage />);
+    expect(screen.getByText('error-404')).toBeTruthy();
+  });
+
+  it('renders the feature when enabled', () => {
+    gate = { enabled: true, loading: false };
+    render(<BuildDiscoveryPage />);
+    expect(screen.getByText('discovery-content')).toBeTruthy();
+  });
+});

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,0 +1,22 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname),
+      common: path.resolve(__dirname, 'common'),
+      components: path.resolve(__dirname, 'components'),
+      graphql: path.resolve(__dirname, 'graphql'),
+      pages: path.resolve(__dirname, 'pages'),
+    },
+  },
+  test: {
+    environment: 'node',
+    exclude: ['**/.next/**', '**/node_modules/**'],
+    restoreMocks: true,
+  },
+});

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -173,12 +173,32 @@
   resolved "https://registry.yarnpkg.com/@artsy/fresnel/-/fresnel-8.1.0.tgz#25dff4bdacda24f94636bbde0cc08e55b0f09f45"
   integrity sha512-zlTUFfMDlJa2rmt631qC3/uwuZlGtLIpJtwddDEYdmy/p2P/rvZej+IXLHTP5a922CUMujWtEJHm/9wh93B2OQ==
 
+"@asamuzakjp/css-color@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz#cc42f5b85c593f79f1fa4f25d2b9b321e61d1794"
+  integrity sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==
+  dependencies:
+    "@csstools/css-calc" "^2.1.3"
+    "@csstools/css-color-parser" "^3.0.9"
+    "@csstools/css-parser-algorithms" "^3.0.4"
+    "@csstools/css-tokenizer" "^3.0.3"
+    lru-cache "^10.4.3"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
   integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.27.1"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
+"@babel/code-frame@^7.10.4":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.29.7"
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
@@ -452,6 +472,11 @@
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
   integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
+
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
 "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
@@ -812,6 +837,34 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
+"@csstools/color-helpers@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.1.0.tgz#106c54c808cabfd1ab4c602d8505ee584c2996ef"
+  integrity sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==
+
+"@csstools/css-calc@^2.1.3", "@csstools/css-calc@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-calc/-/css-calc-2.1.4.tgz#8473f63e2fcd6e459838dd412401d5948f224c65"
+  integrity sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==
+
+"@csstools/css-color-parser@^3.0.9":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz#4e386af3a99dd36c46fef013cfe4c1c341eed6f0"
+  integrity sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==
+  dependencies:
+    "@csstools/color-helpers" "^5.1.0"
+    "@csstools/css-calc" "^2.1.4"
+
+"@csstools/css-parser-algorithms@^3.0.4":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz#5755370a9a29abaec5515b43c8b3f2cf9c2e3076"
+  integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
+
+"@csstools/css-tokenizer@^3.0.3":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz#333fedabc3fd1a8e5d0100013731cf19e6a8c5d3"
+  integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
+
 "@discoveryjs/json-ext@0.5.7":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -972,6 +1025,136 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@epic-web/invariant/-/invariant-1.0.0.tgz#1073e5dee6dd540410784990eb73e4acd25c9813"
   integrity sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==
+
+"@esbuild/aix-ppc64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz#7a01a8d2ec2fbb2dac78adad09b0fa781e4082be"
+  integrity sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==
+
+"@esbuild/android-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz#b540a27d14e4afd058496a4dbec4d3f414db110a"
+  integrity sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==
+
+"@esbuild/android-arm@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.1.tgz#704bd297de6d762de54eabbeafbf55f6756abe2f"
+  integrity sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==
+
+"@esbuild/android-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.1.tgz#d1cb166d34b0fbf0fe8ab460a5594f24a378701e"
+  integrity sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==
+
+"@esbuild/darwin-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz#1034b26457fc886368fe61bbd09f653f6afa8e54"
+  integrity sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==
+
+"@esbuild/darwin-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz#65556a432a1e4d72032d8218c1932fcca1a49772"
+  integrity sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==
+
+"@esbuild/freebsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz#2e61e0592f9030d7e3dae18ee25ebc535918aef6"
+  integrity sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==
+
+"@esbuild/freebsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz#c95ec289959ef8079c4dca817a1e2c4be66b9bd3"
+  integrity sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==
+
+"@esbuild/linux-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz#40b22175dda06182f3ee8141186c5ff304c4a717"
+  integrity sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==
+
+"@esbuild/linux-arm@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz#c09a0f67917592ac0de892a9be4d3814debd2a6c"
+  integrity sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==
+
+"@esbuild/linux-ia32@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz#a580f9c676797833891e519fc7a1337c8afd8db3"
+  integrity sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==
+
+"@esbuild/linux-loong64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz#46452cf321dc7f9e91c2fa780a56bb56e79cd68b"
+  integrity sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==
+
+"@esbuild/linux-mips64el@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz#4211b3184dd6608f53dcb22e39f5d34ee08852c8"
+  integrity sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==
+
+"@esbuild/linux-ppc64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz#697857c2a61cb9b0b6bb6652e40c1dc5e1ca8e5d"
+  integrity sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==
+
+"@esbuild/linux-riscv64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz#d192943eb146a40ac4c6497d0cf7be35b986bf08"
+  integrity sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==
+
+"@esbuild/linux-s390x@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz#acea0356da0e0ebc08f97cf7b9c2e401e1e648dc"
+  integrity sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==
+
+"@esbuild/linux-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz#6f0c3ce0cb64c534b70c4c45ecb2c16d34e35dfd"
+  integrity sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==
+
+"@esbuild/netbsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz#8bcd77077a0dce3378b574fedb26d2a253b73d36"
+  integrity sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==
+
+"@esbuild/netbsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz#e7fb2a01e99c830c94e6623cd9fefb4c8fb58347"
+  integrity sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==
+
+"@esbuild/openbsd-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz#c52909372db8b86e2c55e05a8940033b5660a3b2"
+  integrity sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==
+
+"@esbuild/openbsd-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz#c427b9be5a64c262ff9a7eb70b5fbbaadf446c6c"
+  integrity sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==
+
+"@esbuild/openharmony-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz#dc9b147baca2e6c4b3c85571741ef4860a489097"
+  integrity sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==
+
+"@esbuild/sunos-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz#ce866d12df13c15e4c99f073a3d466f6e0649b3a"
+  integrity sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==
+
+"@esbuild/win32-arm64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz#7468e3692d01d629d5941e5d83817bb80f9e39b4"
+  integrity sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==
+
+"@esbuild/win32-ia32@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz#a5bc0063fb2bcab6d0ed63f2a1537958bc269ec6"
+  integrity sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==
+
+"@esbuild/win32-x64@0.28.1":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz#10064ee44f4347b90c9a02b446bbf80a91632b12"
+  integrity sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==
 
 "@eslint-community/eslint-utils@^4.7.0":
   version "4.7.0"
@@ -1850,7 +2033,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
-"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
+"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
@@ -2167,6 +2350,131 @@
   resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.6.tgz#be23df0143ceec3c69f8b6c2517971a5578fdaa2"
   integrity sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==
 
+"@rollup/rollup-android-arm-eabi@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz#5e9849b661c2229cf967a08dbe2dbbe9e8c991e5"
+  integrity sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==
+
+"@rollup/rollup-android-arm64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz#5b0699ee5dd484b222c9ed74aff43c91ea8b17f8"
+  integrity sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==
+
+"@rollup/rollup-darwin-arm64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz#8bc52c9d7a3ce8d0533c351a9c935de781daa06f"
+  integrity sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==
+
+"@rollup/rollup-darwin-x64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz#ba2ef3e8fb310f0af35588f270cfa5aa96e48764"
+  integrity sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==
+
+"@rollup/rollup-freebsd-arm64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz#93b10bdbfe8ada226b8bc0c02ef6b7f544474d96"
+  integrity sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==
+
+"@rollup/rollup-freebsd-x64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz#3e8aa38ef3c9c300946871e3fdbb0c30e0a20f86"
+  integrity sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz#1d7994384bb0ad1bc41921b506e1642d4f9d7fc3"
+  integrity sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==
+
+"@rollup/rollup-linux-arm-musleabihf@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz#a6540f47cf844a56b80ca9ff95d2acdfb2cef97b"
+  integrity sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==
+
+"@rollup/rollup-linux-arm64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz#404f2045651840cbf48da91ba6d0f490f0bc2cbf"
+  integrity sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==
+
+"@rollup/rollup-linux-arm64-musl@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz#a3404ffddf7b474b48c99b9c893b6247bb765ba5"
+  integrity sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==
+
+"@rollup/rollup-linux-loong64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz#e8aac6d549b377945e349882f199b7c8eb75ca38"
+  integrity sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==
+
+"@rollup/rollup-linux-loong64-musl@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz#6e2e44ea50310b3a582078a915e5feb879c820d4"
+  integrity sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==
+
+"@rollup/rollup-linux-ppc64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz#6898302da6d77a0537cde64b2b4c6b60659bd110"
+  integrity sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==
+
+"@rollup/rollup-linux-ppc64-musl@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz#333717c95dd5a66bef8f63e7ef8a9fd845fd18d0"
+  integrity sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==
+
+"@rollup/rollup-linux-riscv64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz#81bc06ba380352004d01f4826eb7cdccefa05bad"
+  integrity sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==
+
+"@rollup/rollup-linux-riscv64-musl@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz#95a7cd39de21389ad6788a5284eaaa738e29ca4c"
+  integrity sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==
+
+"@rollup/rollup-linux-s390x-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz#06e6db2ec1bc48b5374c7923ef83c2eb024b2452"
+  integrity sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==
+
+"@rollup/rollup-linux-x64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz#5dc818988285e09e88790c6462def72413df2da3"
+  integrity sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==
+
+"@rollup/rollup-linux-x64-musl@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz#2080f4a93349e9afd34be6fc1a37e01fc8bfc80f"
+  integrity sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==
+
+"@rollup/rollup-openbsd-x64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz#21d64a8acb66221724b923e51af5333df1af044b"
+  integrity sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==
+
+"@rollup/rollup-openharmony-arm64@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz#8e0fcd9d02141e337b4c5b5cff576cb9a76b1ba0"
+  integrity sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==
+
+"@rollup/rollup-win32-arm64-msvc@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz#bdb4cc4efd58efe808203347f0f5463f0ea16e52"
+  integrity sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==
+
+"@rollup/rollup-win32-ia32-msvc@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz#dbaebde5afd24eae0eefe915d901632e7cb59860"
+  integrity sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==
+
+"@rollup/rollup-win32-x64-gnu@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz#84109e85fea5f8f1353499f96578fdc2a0e8b138"
+  integrity sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==
+
+"@rollup/rollup-win32-x64-msvc@4.62.2":
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz#3671ce3f9b928d5c01f879792d5c0b60ae14d4ad"
+  integrity sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==
+
 "@rrweb/record@2.0.0-alpha.17":
   version "2.0.0-alpha.17"
   resolved "https://registry.yarnpkg.com/@rrweb/record/-/record-2.0.0-alpha.17.tgz#4f306a8dfcdbb56419b59bb1cb0f5cbea073cafc"
@@ -2252,6 +2560,27 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testing-library/dom@10.4.0":
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.0.tgz#82a9d9462f11d240ecadbf406607c6ceeeff43a8"
+  integrity sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.3.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@16.3.0":
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.3.0.tgz#3a85bb9bdebf180cd76dba16454e242564d598a6"
+  integrity sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@theguild/federation-composition@^0.19.0":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@theguild/federation-composition/-/federation-composition-0.19.1.tgz#b3907bfcbdbd69d4628a3b1270936615f56b904f"
@@ -2269,6 +2598,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
+
 "@types/body-parser@*":
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
@@ -2276,6 +2610,14 @@
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
+
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
 
 "@types/connect@*":
   version "3.4.35"
@@ -2288,6 +2630,11 @@
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz#2f98ede46acc0975de85c0b7b0ebe06041d24601"
   integrity sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/eslint-scope@^3.7.0":
   version "3.7.3"
@@ -2309,6 +2656,11 @@
   version "0.0.50"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
   integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
+
+"@types/estree@1.0.9", "@types/estree@^1.0.0":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
 
 "@types/express-serve-static-core@^4.17.18":
   version "4.17.28"
@@ -2634,6 +2986,74 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
+"@vitest/expect@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.2.4.tgz#8362124cd811a5ee11c5768207b9df53d34f2433"
+  integrity sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==
+  dependencies:
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "3.2.4"
+    "@vitest/utils" "3.2.4"
+    chai "^5.2.0"
+    tinyrainbow "^2.0.0"
+
+"@vitest/mocker@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.2.4.tgz#4471c4efbd62db0d4fa203e65cc6b058a85cabd3"
+  integrity sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==
+  dependencies:
+    "@vitest/spy" "3.2.4"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.17"
+
+"@vitest/pretty-format@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.4.tgz#3c102f79e82b204a26c7a5921bf47d534919d3b4"
+  integrity sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==
+  dependencies:
+    tinyrainbow "^2.0.0"
+
+"@vitest/pretty-format@^3.2.4":
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.7.tgz#2a7b593f8e007e9d8ef7e7343aa30ec73fdeaf29"
+  integrity sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==
+  dependencies:
+    tinyrainbow "^2.0.0"
+
+"@vitest/runner@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.2.4.tgz#5ce0274f24a971f6500f6fc166d53d8382430766"
+  integrity sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==
+  dependencies:
+    "@vitest/utils" "3.2.4"
+    pathe "^2.0.3"
+    strip-literal "^3.0.0"
+
+"@vitest/snapshot@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.2.4.tgz#40a8bc0346ac0aee923c0eefc2dc005d90bc987c"
+  integrity sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==
+  dependencies:
+    "@vitest/pretty-format" "3.2.4"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+
+"@vitest/spy@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.2.4.tgz#cc18f26f40f3f028da6620046881f4e4518c2599"
+  integrity sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==
+  dependencies:
+    tinyspy "^4.0.3"
+
+"@vitest/utils@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.2.4.tgz#c0813bc42d99527fb8c5b138c7a88516bca46fea"
+  integrity sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==
+  dependencies:
+    "@vitest/pretty-format" "3.2.4"
+    loupe "^3.1.4"
+    tinyrainbow "^2.0.0"
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
@@ -2931,6 +3351,11 @@ acorn@^8.0.4, acorn@^8.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
 ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -2990,6 +3415,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-styles@^6.0.0, ansi-styles@^6.2.1:
   version "6.2.3"
@@ -3075,6 +3505,13 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
 
 aria-query@^5.3.2:
   version "5.3.2"
@@ -3186,6 +3623,11 @@ asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 ast-types-flow@^0.0.8:
   version "0.0.8"
@@ -3404,6 +3846,11 @@ bytes@3.1.1:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a"
   integrity sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 cacheable-request@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
@@ -3493,6 +3940,17 @@ capital-case@^1.0.4:
     tslib "^2.0.3"
     upper-case-first "^2.0.2"
 
+chai@^5.2.0:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
+  integrity sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
 chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -3564,6 +4022,11 @@ chardet@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.1.0.tgz#1007f441a1ae9f9199a4a67f6e978fb0aa9aa3fe"
   integrity sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==
+
+check-error@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
+  integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
 chokidar@^3.5.2:
   version "3.5.3"
@@ -3912,6 +4375,14 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+cssstyle@^4.2.1:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.6.0.tgz#ea18007024e3167f4f105315f3ec2d982bf48ed9"
+  integrity sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==
+  dependencies:
+    "@asamuzakjp/css-color" "^3.2.0"
+    rrweb-cssom "^0.8.0"
+
 csstype@^3.0.2, csstype@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
@@ -3926,6 +4397,14 @@ data-uri-to-buffer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
+data-urls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-5.0.0.tgz#2f76906bce1824429ffecb6920f45a0b30f00dde"
+  integrity sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==
+  dependencies:
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
 
 data-view-buffer@^1.0.2:
   version "1.0.2"
@@ -3981,6 +4460,13 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@4, debug@^4.4.1:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 debug@4.4.1, debug@^4.3.1, debug@^4.3.4, debug@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
@@ -4007,12 +4493,22 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
+decimal.js@^10.5.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
+
 decompress-response@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
   integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
   dependencies:
     mimic-response "^1.0.0"
+
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -4069,6 +4565,11 @@ dependency-graph@^1.0.0:
   resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-1.0.0.tgz#bb5e85aec1310bc13b22dbd76e3196c4ee4c10d2"
   integrity sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==
 
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -4107,6 +4608,11 @@ doctrine@^2.1.0:
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -4239,6 +4745,11 @@ ensure-array@^1.0.0:
   resolved "https://registry.yarnpkg.com/ensure-array/-/ensure-array-1.0.0.tgz#317e9fc632c656bb849eb649133528e205b23abc"
   integrity sha512-A+3Ntl5WS+GjDnHtC67dKIjw+IoGoeFdNvjn3ZfKEmZgWUz0nxBPE4W52QMCbGZsat0VwWskD5T6AEpe3T2d1g==
 
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
+
 env-paths@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
@@ -4363,6 +4874,11 @@ es-module-lexer@^0.9.0:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
   integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
 
+es-module-lexer@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
@@ -4395,6 +4911,38 @@ es-to-primitive@^1.3.0:
     is-callable "^1.2.7"
     is-date-object "^1.0.5"
     is-symbol "^1.0.4"
+
+"esbuild@^0.27.0 || ^0.28.0":
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.1.tgz#ef45b4634c9c9d97a296aea4114a5f9840f95578"
+  integrity sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.28.1"
+    "@esbuild/android-arm" "0.28.1"
+    "@esbuild/android-arm64" "0.28.1"
+    "@esbuild/android-x64" "0.28.1"
+    "@esbuild/darwin-arm64" "0.28.1"
+    "@esbuild/darwin-x64" "0.28.1"
+    "@esbuild/freebsd-arm64" "0.28.1"
+    "@esbuild/freebsd-x64" "0.28.1"
+    "@esbuild/linux-arm" "0.28.1"
+    "@esbuild/linux-arm64" "0.28.1"
+    "@esbuild/linux-ia32" "0.28.1"
+    "@esbuild/linux-loong64" "0.28.1"
+    "@esbuild/linux-mips64el" "0.28.1"
+    "@esbuild/linux-ppc64" "0.28.1"
+    "@esbuild/linux-riscv64" "0.28.1"
+    "@esbuild/linux-s390x" "0.28.1"
+    "@esbuild/linux-x64" "0.28.1"
+    "@esbuild/netbsd-arm64" "0.28.1"
+    "@esbuild/netbsd-x64" "0.28.1"
+    "@esbuild/openbsd-arm64" "0.28.1"
+    "@esbuild/openbsd-x64" "0.28.1"
+    "@esbuild/openharmony-arm64" "0.28.1"
+    "@esbuild/sunos-x64" "0.28.1"
+    "@esbuild/win32-arm64" "0.28.1"
+    "@esbuild/win32-ia32" "0.28.1"
+    "@esbuild/win32-x64" "0.28.1"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -4586,6 +5134,13 @@ estraverse@^5.2.0, estraverse@^5.3.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -4605,6 +5160,11 @@ events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
+expect-type@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.4.0.tgz#24edf7f0cc69a44d008567ba4594ab96f3c3a3d6"
+  integrity sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==
 
 express@^4.17.1:
   version "4.17.2"
@@ -4711,7 +5271,7 @@ fbjs@^3.0.0:
     setimmediate "^1.0.5"
     ua-parser-js "^1.0.35"
 
-fdir@^6.4.4:
+fdir@^6.4.4, fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
@@ -4820,6 +5380,11 @@ fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
+fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -5175,6 +5740,13 @@ hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-
   dependencies:
     react-is "^16.7.0"
 
+html-encoding-sniffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
+  integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
+  dependencies:
+    whatwg-encoding "^3.1.1"
+
 html-escaper@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
@@ -5202,6 +5774,22 @@ http-errors@1.8.1:
     setprototypeof "1.2.0"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
+
+http-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
+https-proxy-agent@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
 
 i18next-fs-backend@^2.6.0:
   version "2.6.0"
@@ -5255,7 +5843,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.3:
+iconv-lite@0.6.3, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -5595,6 +6183,11 @@ is-plain-object@^5.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 is-regex@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.2.1.tgz#76d70a3ed10ef9be48eb577887d74205bf0cad22"
@@ -5781,12 +6374,43 @@ js-cookie@^3.0.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-tokens@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.1.tgz#2ec43964658435296f6761b34e10671c2d9527f4"
+  integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
+
 js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+jsdom@26.1.0:
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-26.1.0.tgz#ab5f1c1cafc04bd878725490974ea5e8bf0c72b3"
+  integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
+  dependencies:
+    cssstyle "^4.2.1"
+    data-urls "^5.0.0"
+    decimal.js "^10.5.0"
+    html-encoding-sniffer "^4.0.0"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.6"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.16"
+    parse5 "^7.2.1"
+    rrweb-cssom "^0.8.0"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^5.1.1"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^3.1.1"
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.1.1"
+    ws "^8.18.0"
+    xml-name-validator "^5.0.0"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -5991,6 +6615,11 @@ loose-envify@^1.0.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loupe@^3.1.0, loupe@^3.1.4:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
+  integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
+
 lower-case-first@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-2.0.2.tgz#64c2324a2250bf7c37c5901e76a5b5309301160b"
@@ -6015,6 +6644,11 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lru-cache@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -6028,6 +6662,18 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
+magic-string@^0.30.17:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -6362,6 +7008,11 @@ nullthrows@^1.1.1:
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
 
+nwsapi@^2.2.16:
+  version "2.2.24"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.24.tgz#f8927043d4c9b516abdebe804a32c8d1f9484d1f"
+  integrity sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==
+
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -6567,6 +7218,13 @@ parse5@^5.0.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
+parse5@^7.2.1:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
 parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -6635,6 +7293,16 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathval@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
+  integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -6655,6 +7323,11 @@ picomatch@^4.0.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
+picomatch@^4.0.3, picomatch@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
+
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
@@ -6669,7 +7342,7 @@ postcss@8.4.31:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@^8.4.38:
+postcss@^8.4.38, postcss@^8.5.6:
   version "8.5.19"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.19.tgz#45ad5cfde499408e20147348237551381a922037"
   integrity sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==
@@ -6682,6 +7355,15 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -6746,6 +7428,11 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 pupa@^2.1.1:
   version "2.1.1"
@@ -7230,6 +7917,11 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
 react-is@^18.2.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
@@ -7447,12 +8139,51 @@ rfdc@^1.4.1:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
+rollup@^4.43.0:
+  version "4.62.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.62.2.tgz#d90fc4cb811f071303c890b779595634f35f9541"
+  integrity sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==
+  dependencies:
+    "@types/estree" "1.0.9"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.62.2"
+    "@rollup/rollup-android-arm64" "4.62.2"
+    "@rollup/rollup-darwin-arm64" "4.62.2"
+    "@rollup/rollup-darwin-x64" "4.62.2"
+    "@rollup/rollup-freebsd-arm64" "4.62.2"
+    "@rollup/rollup-freebsd-x64" "4.62.2"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.62.2"
+    "@rollup/rollup-linux-arm-musleabihf" "4.62.2"
+    "@rollup/rollup-linux-arm64-gnu" "4.62.2"
+    "@rollup/rollup-linux-arm64-musl" "4.62.2"
+    "@rollup/rollup-linux-loong64-gnu" "4.62.2"
+    "@rollup/rollup-linux-loong64-musl" "4.62.2"
+    "@rollup/rollup-linux-ppc64-gnu" "4.62.2"
+    "@rollup/rollup-linux-ppc64-musl" "4.62.2"
+    "@rollup/rollup-linux-riscv64-gnu" "4.62.2"
+    "@rollup/rollup-linux-riscv64-musl" "4.62.2"
+    "@rollup/rollup-linux-s390x-gnu" "4.62.2"
+    "@rollup/rollup-linux-x64-gnu" "4.62.2"
+    "@rollup/rollup-linux-x64-musl" "4.62.2"
+    "@rollup/rollup-openbsd-x64" "4.62.2"
+    "@rollup/rollup-openharmony-arm64" "4.62.2"
+    "@rollup/rollup-win32-arm64-msvc" "4.62.2"
+    "@rollup/rollup-win32-ia32-msvc" "4.62.2"
+    "@rollup/rollup-win32-x64-gnu" "4.62.2"
+    "@rollup/rollup-win32-x64-msvc" "4.62.2"
+    fsevents "~2.3.2"
+
 rrdom@^2.0.0-alpha.17, rrdom@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/rrdom/-/rrdom-2.1.0.tgz#2b7a21e782667b5317aff27b2c2aa71de21c5256"
   integrity sha512-d7oaIHzwffxI74UJMZDGq/f97/Yfm3QX4CcTIlQelt2HsLavItLjp8x8nQ0g9Pet5+5wG1RGr9yvsxb1gJlo8A==
   dependencies:
     rrweb-snapshot "^2.1.0"
+
+rrweb-cssom@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
+  integrity sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==
 
 rrweb-snapshot@^2.0.0-alpha.17, rrweb-snapshot@^2.1.0:
   version "2.1.0"
@@ -7538,6 +8269,13 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 scheduler@^0.26.0:
   version "0.26.0"
@@ -7786,6 +8524,11 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.2:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
@@ -7900,10 +8643,20 @@ stable-hash@^0.0.5:
   resolved "https://registry.yarnpkg.com/stable-hash/-/stable-hash-0.0.5.tgz#94e8837aaeac5b4d0f631d2972adef2924b40269"
   integrity sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+std-env@^3.9.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
@@ -8052,6 +8805,13 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+strip-literal@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-3.1.0.tgz#222b243dd2d49c0bcd0de8906adbd84177196032"
+  integrity sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==
+  dependencies:
+    js-tokens "^9.0.1"
+
 styled-jsx@5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.1.6.tgz#83b90c077e6c6a80f7f5e8781d0f311b2fe41499"
@@ -8106,6 +8866,11 @@ symbol-observable@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
   integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
+
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
 sync-fetch@0.6.0-2:
   version "0.6.0-2"
@@ -8175,6 +8940,16 @@ timeout-signal@^2.0.0:
   resolved "https://registry.yarnpkg.com/timeout-signal/-/timeout-signal-2.0.0.tgz#23207ea448d50258bb0defe3beea4a467643abba"
   integrity sha512-YBGpG4bWsHoPvofT6y/5iqulfXIiIErl5B0LdtHT1mGXDFTAhhRrbUpTvBgYbovr+3cKblya2WAOcpoy90XguA==
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
 tinyglobby@^0.2.13:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.14.tgz#5280b0cf3f972b050e74ae88406c0a6a58f4079d"
@@ -8183,12 +8958,47 @@ tinyglobby@^0.2.13:
     fdir "^6.4.4"
     picomatch "^4.0.2"
 
+tinyglobby@^0.2.14, tinyglobby@^0.2.15:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
+tinypool@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
+
+tinyrainbow@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
+  integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
+
+tinyspy@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-4.0.4.tgz#d77a002fb53a88aa1429b419c1c92492e0c81f78"
+  integrity sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==
+
 title-case@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/title-case/-/title-case-3.0.3.tgz#bc689b46f02e411f1d1e1d081f7c3deca0489982"
   integrity sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==
   dependencies:
     tslib "^2.0.3"
+
+tldts-core@^6.1.86:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.86.tgz#a93e6ed9d505cb54c542ce43feb14c73913265d8"
+  integrity sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==
+
+tldts@^6.1.32:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.86.tgz#087e0555b31b9725ee48ca7e77edc56115cd82f7"
+  integrity sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==
+  dependencies:
+    tldts-core "^6.1.86"
 
 to-absolute-glob@^2.0.0:
   version "2.0.2"
@@ -8243,6 +9053,20 @@ touch@^3.1.0:
   integrity sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==
   dependencies:
     nopt "~1.0.10"
+
+tough-cookie@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.2.tgz#66d774b4a1d9e12dc75089725af3ac75ec31bed7"
+  integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
+  dependencies:
+    tldts "^6.1.32"
+
+tr46@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.1.1.tgz#96ae867cddb8fdb64a49cc3059a8d428bcf238ca"
+  integrity sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==
+  dependencies:
+    punycode "^2.3.1"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -8605,10 +9429,71 @@ vinyl@^2.0.0, vinyl@^2.2.0:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
+vite-node@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.2.4.tgz#f3676d94c4af1e76898c162c92728bca65f7bb07"
+  integrity sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.4.1"
+    es-module-lexer "^1.7.0"
+    pathe "^2.0.3"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+
+"vite@^5.0.0 || ^6.0.0 || ^7.0.0-0":
+  version "7.3.6"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.3.6.tgz#0547a395e68d3746e9a505f1fd4469fe09b49cc4"
+  integrity sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==
+  dependencies:
+    esbuild "^0.27.0 || ^0.28.0"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.6"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.2.4.tgz#0637b903ad79d1539a25bc34c0ed54b5c67702ea"
+  integrity sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==
+  dependencies:
+    "@types/chai" "^5.2.2"
+    "@vitest/expect" "3.2.4"
+    "@vitest/mocker" "3.2.4"
+    "@vitest/pretty-format" "^3.2.4"
+    "@vitest/runner" "3.2.4"
+    "@vitest/snapshot" "3.2.4"
+    "@vitest/spy" "3.2.4"
+    "@vitest/utils" "3.2.4"
+    chai "^5.2.0"
+    debug "^4.4.1"
+    expect-type "^1.2.1"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+    picomatch "^4.0.2"
+    std-env "^3.9.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinyglobby "^0.2.14"
+    tinypool "^1.1.1"
+    tinyrainbow "^2.0.0"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    vite-node "3.2.4"
+    why-is-node-running "^2.3.0"
+
 void-elements@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
   integrity sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=
+
+w3c-xmlserializer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
+  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
+  dependencies:
+    xml-name-validator "^5.0.0"
 
 watchpack@^2.3.1:
   version "2.3.1"
@@ -8632,6 +9517,11 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
 webpack-bundle-analyzer@4.10.1:
   version "4.10.1"
@@ -8687,10 +9577,25 @@ webpack@^5.67.0:
     watchpack "^2.3.1"
     webpack-sources "^3.2.3"
 
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-mimetype@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
   integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
+
+whatwg-url@^14.0.0, whatwg-url@^14.1.1:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.2.0.tgz#4ee02d5d725155dae004f6ae95c73e7ef5d95663"
+  integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
+  dependencies:
+    tr46 "^5.1.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -8765,6 +9670,14 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
+
 widest-line@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-3.1.0.tgz#8292333bbf66cb45ff0de1603b136b7ae1496eca"
@@ -8824,10 +9737,25 @@ ws@^8.17.1, ws@^8.18.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
   integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
+ws@^8.18.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
+
 xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
+xml-name-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
+  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"

--- a/server/oneoff/damage_calculator.py
+++ b/server/oneoff/damage_calculator.py
@@ -85,8 +85,12 @@ def calc_damage(
 
 
 def average_line_damage(line: DamageLine, stats: dict[str, int]) -> float:
-    crit_base_min = line.crit_base_min if line.crit_base_min is not None else line.base_min
-    crit_base_max = line.crit_base_max if line.crit_base_max is not None else line.base_max
+    crit_base_min = (
+        line.crit_base_min if line.crit_base_min is not None else line.base_min
+    )
+    crit_base_max = (
+        line.crit_base_max if line.crit_base_max is not None else line.base_max
+    )
     noncrit_min = calc_damage(
         line.base_min,
         line.element,

--- a/server/oneoff/fixtures/parity/condition_cases.json
+++ b/server/oneoff/fixtures/parity/condition_cases.json
@@ -1,0 +1,257 @@
+{
+  "fixtureVersion": "condition-parity-v1",
+  "contract": "Item condition evaluation shared by the client build validator and Build Discovery.",
+  "cases": [
+    {
+      "name": "less_than_below_boundary",
+      "condition": { "stat": "AP", "operator": "<", "value": 12 },
+      "stats": { "AP": 11 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "less_than_exact_boundary",
+      "condition": { "stat": "AP", "operator": "<", "value": 12 },
+      "stats": { "AP": 12 },
+      "setCounts": {},
+      "expected": false
+    },
+    {
+      "name": "greater_than_above_boundary",
+      "condition": { "stat": "MP", "operator": ">", "value": 5 },
+      "stats": { "MP": 6 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "greater_than_exact_boundary",
+      "condition": { "stat": "MP", "operator": ">", "value": 5 },
+      "stats": { "MP": 5 },
+      "setCounts": {},
+      "expected": false
+    },
+    {
+      "name": "zero_value_less_than",
+      "condition": { "stat": "POWER", "operator": "<", "value": 0 },
+      "stats": { "Power": -1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "zero_value_greater_than_exact",
+      "condition": { "stat": "POWER", "operator": ">", "value": 0 },
+      "stats": { "Power": 0 },
+      "setCounts": {},
+      "expected": false
+    },
+    {
+      "name": "unknown_stat_defaults_to_zero",
+      "condition": { "stat": "UNKNOWN_STAT", "operator": ">", "value": -1 },
+      "stats": {},
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "unknown_operator_fails_open",
+      "condition": { "stat": "AP", "operator": "=", "value": 12 },
+      "stats": { "AP": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "empty_tree_fails_open",
+      "condition": {},
+      "stats": {},
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "empty_and_fails_open",
+      "condition": { "and": [] },
+      "stats": {},
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "empty_or_fails_open",
+      "condition": { "or": [] },
+      "stats": {},
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "malformed_missing_value_fails_open",
+      "condition": { "stat": "AP", "operator": "<" },
+      "stats": { "AP": 99 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "malformed_unknown_shape_fails_open",
+      "condition": { "unexpected": [{ "stat": "AP" }] },
+      "stats": {},
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "nested_and_or_passes",
+      "condition": {
+        "and": [
+          { "stat": "AP", "operator": ">", "value": 10 },
+          {
+            "or": [
+              { "stat": "MP", "operator": ">", "value": 6 },
+              { "stat": "RANGE", "operator": ">", "value": 2 }
+            ]
+          }
+        ]
+      },
+      "stats": { "AP": 11, "MP": 6, "Range": 3 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "nested_and_or_fails",
+      "condition": {
+        "and": [
+          { "stat": "AP", "operator": ">", "value": 10 },
+          {
+            "or": [
+              { "stat": "MP", "operator": ">", "value": 6 },
+              { "stat": "RANGE", "operator": ">", "value": 2 }
+            ]
+          }
+        ]
+      },
+      "stats": { "AP": 11, "MP": 6, "Range": 2 },
+      "setCounts": {},
+      "expected": false
+    },
+    {
+      "name": "set_bonus_counts_extra_items_across_sets",
+      "condition": { "stat": "SET_BONUS", "operator": ">", "value": 2 },
+      "stats": {},
+      "setCounts": { "set-a": 3, "set-b": 2, "set-c": 1 },
+      "expected": true
+    },
+    {
+      "name": "set_bonus_exact_boundary",
+      "condition": { "stat": "SET_BONUS", "operator": "<", "value": 3 },
+      "stats": {},
+      "setCounts": { "set-a": 3, "set-b": 2 },
+      "expected": false
+    },
+    {
+      "name": "mapping_range",
+      "condition": { "stat": "RANGE", "operator": ">", "value": 0 },
+      "stats": { "Range": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_vitality",
+      "condition": { "stat": "VITALITY", "operator": ">", "value": 0 },
+      "stats": { "Vitality": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_wisdom",
+      "condition": { "stat": "WISDOM", "operator": ">", "value": 0 },
+      "stats": { "Wisdom": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_strength",
+      "condition": { "stat": "STRENGTH", "operator": ">", "value": 0 },
+      "stats": { "Strength": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_intelligence",
+      "condition": { "stat": "INTELLIGENCE", "operator": ">", "value": 0 },
+      "stats": { "Intelligence": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_chance",
+      "condition": { "stat": "CHANCE", "operator": ">", "value": 0 },
+      "stats": { "Chance": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_agility",
+      "condition": { "stat": "AGILITY", "operator": ">", "value": 0 },
+      "stats": { "Agility": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_critical",
+      "condition": { "stat": "CRITICAL", "operator": ">", "value": 0 },
+      "stats": { "Critical": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_dodge",
+      "condition": { "stat": "DODGE", "operator": ">", "value": 0 },
+      "stats": { "Dodge": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_lock",
+      "condition": { "stat": "LOCK", "operator": ">", "value": 0 },
+      "stats": { "Lock": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_damage",
+      "condition": { "stat": "DAMAGE", "operator": ">", "value": 0 },
+      "stats": { "Damage": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_earth_damage",
+      "condition": { "stat": "EARTH_DAMAGE", "operator": ">", "value": 0 },
+      "stats": { "Earth Damage": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_neutral_damage",
+      "condition": { "stat": "NEUTRAL_DAMAGE", "operator": ">", "value": 0 },
+      "stats": { "Neutral Damage": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_fire_damage",
+      "condition": { "stat": "FIRE_DAMAGE", "operator": ">", "value": 0 },
+      "stats": { "Fire Damage": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_water_damage",
+      "condition": { "stat": "WATER_DAMAGE", "operator": ">", "value": 0 },
+      "stats": { "Water Damage": 1 },
+      "setCounts": {},
+      "expected": true
+    },
+    {
+      "name": "mapping_air_damage",
+      "condition": { "stat": "AIR_DAMAGE", "operator": ">", "value": 0 },
+      "stats": { "Air Damage": 1 },
+      "setCounts": {},
+      "expected": true
+    }
+  ]
+}

--- a/server/oneoff/fixtures/parity/damage_cases.json
+++ b/server/oneoff/fixtures/parity/damage_cases.json
@@ -1,0 +1,236 @@
+{
+  "fixtureVersion": "damage-parity-v1",
+  "contract": "Outgoing pre-resistance damage shared by client calcDamage and oneoff.damage_calculator.calc_damage.",
+  "resistanceDecision": "Defender resistance is outside the backend solver contract and neither compared outgoing-damage API accepts resistance parameters.",
+  "cases": [
+    {
+      "name": "zero_base_boundary",
+      "baseDamage": 0,
+      "element": "earth",
+      "stats": {},
+      "flags": {},
+      "expected": { "melee": 0, "ranged": 0 }
+    },
+    {
+      "name": "exact_integer_percentage_boundary",
+      "baseDamage": 18,
+      "element": "earth",
+      "stats": { "% Final Damage": 20, "% Melee Damage": 25 },
+      "flags": {},
+      "expected": { "melee": 27, "ranged": 21 }
+    },
+    {
+      "name": "earth_characteristic",
+      "baseDamage": 10,
+      "element": "earth",
+      "stats": { "Strength": 100 },
+      "flags": {},
+      "expected": { "melee": 20, "ranged": 20 }
+    },
+    {
+      "name": "neutral_elemental_and_generic_fixed",
+      "baseDamage": 10,
+      "element": "neutral",
+      "stats": { "Strength": 100, "Neutral Damage": 5, "Damage": 3 },
+      "flags": {},
+      "expected": { "melee": 28, "ranged": 28 }
+    },
+    {
+      "name": "fire_characteristic_power_fixed",
+      "baseDamage": 19,
+      "element": "fire",
+      "stats": {
+        "Intelligence": 123,
+        "Power": 47,
+        "Fire Damage": 8,
+        "Damage": 4
+      },
+      "flags": {},
+      "expected": { "melee": 63, "ranged": 63 }
+    },
+    {
+      "name": "water_negative_stats",
+      "baseDamage": 17,
+      "element": "water",
+      "stats": { "Chance": -50, "Power": -25, "Water Damage": -2, "Damage": 3 },
+      "flags": {},
+      "expected": { "melee": 5, "ranged": 5 }
+    },
+    {
+      "name": "air_characteristic_and_power",
+      "baseDamage": 13,
+      "element": "air",
+      "stats": { "Agility": 201, "Power": 99, "Air Damage": 7 },
+      "flags": {},
+      "expected": { "melee": 59, "ranged": 59 }
+    },
+    {
+      "name": "critical_damage_and_line_bonus",
+      "baseDamage": 25,
+      "element": "fire",
+      "stats": { "Intelligence": 80, "Critical Damage": 12 },
+      "flags": { "isCrit": true, "critBonusDamage": 5 },
+      "expected": { "melee": 62, "ranged": 62 }
+    },
+    {
+      "name": "noncrit_ignores_critical_bonuses",
+      "baseDamage": 25,
+      "element": "fire",
+      "stats": { "Intelligence": 80, "Critical Damage": 12 },
+      "flags": { "critBonusDamage": 5 },
+      "expected": { "melee": 45, "ranged": 45 }
+    },
+    {
+      "name": "trap_power_and_damage",
+      "baseDamage": 21,
+      "element": "earth",
+      "stats": { "Strength": 50, "Trap Power": 75, "Trap Damage": 9 },
+      "flags": { "isTrap": true },
+      "expected": { "melee": 56, "ranged": 56 }
+    },
+    {
+      "name": "weapon_skill_power",
+      "baseDamage": 30,
+      "element": "neutral",
+      "stats": { "Strength": 100 },
+      "flags": { "isWeapon": true, "weaponSkillPower": 20 },
+      "expected": { "melee": 66, "ranged": 66 }
+    },
+    {
+      "name": "spell_final_melee_ranged_modifiers",
+      "baseDamage": 37,
+      "element": "water",
+      "stats": {
+        "Chance": 137,
+        "% Final Damage": 11,
+        "% Spell Damage": 13,
+        "% Melee Damage": 17,
+        "% Ranged Damage": 19
+      },
+      "flags": {},
+      "expected": { "melee": 127, "ranged": 129 }
+    },
+    {
+      "name": "weapon_final_melee_ranged_modifiers",
+      "baseDamage": 37,
+      "element": "neutral",
+      "stats": {
+        "Strength": 137,
+        "% Final Damage": 11,
+        "% Weapon Damage": 13,
+        "% Melee Damage": 17,
+        "% Ranged Damage": 19
+      },
+      "flags": { "isWeapon": true, "weaponSkillPower": 15 },
+      "expected": { "melee": 136, "ranged": 138 }
+    },
+    {
+      "name": "weapon_ignores_spell_modifier",
+      "baseDamage": 20,
+      "element": "earth",
+      "stats": { "Strength": 100, "% Spell Damage": 50, "% Weapon Damage": 10 },
+      "flags": { "isWeapon": true },
+      "expected": { "melee": 44, "ranged": 44 }
+    },
+    {
+      "name": "spell_ignores_weapon_modifier",
+      "baseDamage": 20,
+      "element": "earth",
+      "stats": { "Strength": 100, "% Spell Damage": 10, "% Weapon Damage": 50 },
+      "flags": {},
+      "expected": { "melee": 44, "ranged": 44 }
+    },
+    {
+      "name": "negative_final_and_distance_modifiers",
+      "baseDamage": 40,
+      "element": "air",
+      "stats": {
+        "Agility": 100,
+        "% Final Damage": -10,
+        "% Spell Damage": -20,
+        "% Melee Damage": -30,
+        "% Ranged Damage": -40
+      },
+      "flags": {},
+      "expected": { "melee": 40, "ranged": 34 }
+    },
+    {
+      "name": "floor_before_final_modifiers",
+      "baseDamage": 7,
+      "element": "fire",
+      "stats": {
+        "Intelligence": 33,
+        "Fire Damage": 1,
+        "% Final Damage": 7,
+        "% Spell Damage": 9,
+        "% Melee Damage": 11,
+        "% Ranged Damage": 13
+      },
+      "flags": {},
+      "expected": { "melee": 12, "ranged": 13 }
+    },
+    {
+      "name": "binary_float_floor_boundary",
+      "baseDamage": 29,
+      "element": "water",
+      "stats": {
+        "Chance": 10,
+        "Power": 10,
+        "Damage": 1,
+        "% Final Damage": 10,
+        "% Spell Damage": 10,
+        "% Melee Damage": 10,
+        "% Ranged Damage": 10
+      },
+      "flags": {},
+      "expected": { "melee": 46, "ranged": 46 }
+    },
+    {
+      "name": "all_additive_dimensions",
+      "baseDamage": 31,
+      "element": "air",
+      "stats": {
+        "Agility": 90,
+        "Power": 40,
+        "Air Damage": 6,
+        "Damage": 4,
+        "Critical Damage": 8,
+        "Trap Power": 20,
+        "Trap Damage": 3
+      },
+      "flags": { "isCrit": true, "isTrap": true, "critBonusDamage": 2 },
+      "expected": { "melee": 100, "ranged": 100 }
+    },
+    {
+      "name": "all_multiplicative_weapon_dimensions",
+      "baseDamage": 31,
+      "element": "neutral",
+      "stats": {
+        "Strength": 90,
+        "Power": 40,
+        "Neutral Damage": 6,
+        "Damage": 4,
+        "Critical Damage": 8,
+        "% Final Damage": 12,
+        "% Weapon Damage": 14,
+        "% Melee Damage": 16,
+        "% Ranged Damage": 18
+      },
+      "flags": {
+        "isCrit": true,
+        "isWeapon": true,
+        "weaponSkillPower": 25,
+        "critBonusDamage": 2
+      },
+      "expected": { "melee": 146, "ranged": 149 }
+    },
+    {
+      "name": "negative_calculated_damage_floor",
+      "baseDamage": 5,
+      "element": "earth",
+      "stats": { "Strength": -150, "Earth Damage": -2 },
+      "flags": {},
+      "expected": { "melee": -5, "ranged": -5 }
+    }
+  ]
+}

--- a/server/oneoff/test_frontend_parity.py
+++ b/server/oneoff/test_frontend_parity.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+import unittest
+
+from oneoff.condition_evaluator import traverse_conditions
+from oneoff.damage_calculator import calc_damage
+
+
+FIXTURE_DIRECTORY = Path(__file__).parent / "fixtures" / "parity"
+
+
+def load_fixture(name):
+    with (FIXTURE_DIRECTORY / name).open(encoding="utf-8") as fixture_file:
+        return json.load(fixture_file)
+
+
+class FrontendDamageParityTests(unittest.TestCase):
+    def test_checked_in_damage_expectations(self):
+        fixture = load_fixture("damage_cases.json")
+        self.assertIn(
+            "outside the backend solver contract", fixture["resistanceDecision"]
+        )
+
+        for case in fixture["cases"]:
+            flags = case["flags"]
+            with self.subTest(case=case["name"]):
+                result = calc_damage(
+                    case["baseDamage"],
+                    case["element"],
+                    case["stats"],
+                    is_crit=flags.get("isCrit", False),
+                    is_trap=flags.get("isTrap", False),
+                    is_weapon=flags.get("isWeapon", False),
+                    weapon_skill_power=flags.get("weaponSkillPower", 0),
+                    crit_bonus_damage=flags.get("critBonusDamage", 0),
+                )
+                self.assertEqual(
+                    {key: result[key] for key in ("melee", "ranged")},
+                    case["expected"],
+                )
+
+
+class FrontendConditionParityTests(unittest.TestCase):
+    def test_checked_in_condition_expectations(self):
+        fixture = load_fixture("condition_cases.json")
+
+        for case in fixture["cases"]:
+            with self.subTest(case=case["name"]):
+                self.assertEqual(
+                    traverse_conditions(
+                        case["condition"], case["stats"], case["setCounts"]
+                    ),
+                    case["expected"],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Recreates #506 and folds in #507 after rollback #508.

Stack 7/7, based on the server gate PR. Adds frontend/backend damage and condition parity fixtures, navigation tests, and requires an authenticated DofusLab user before evaluating the client gate.