### PR TITLE
Add transactional catalog revision manifest

### DIFF
--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -1,5 +1,5 @@
 from dotenv import load_dotenv
-from flask import Flask, escape, request, session, g
+from flask import Flask, escape, request, session, g, jsonify, make_response
 from flask_session import Session
 from flask_babel import Babel, _, ngettext
 from flask_bcrypt import Bcrypt
@@ -10,6 +10,8 @@ from flask_limiter_graphQL_support import Limiter
 from flask_limiter_graphQL_support.util import get_remote_address
 import os
 from app.database.base import Base
+from app.catalog_manifest import catalog_manifest, catalog_manifest_etag
+from app.catalog_revision import get_catalog_revision
 from flask_login import LoginManager, current_user
 from flask_cors import CORS
 import redis
@@ -213,6 +215,19 @@ app.add_url_rule(
         "graphql", schema=schema, graphiql=flask_env == "development"
     ),
 )
+
+
+@app.route("/api/catalog/manifest.json", methods=["GET"])
+def get_catalog_manifest():
+    manifest = catalog_manifest(get_catalog_revision(db.session))
+    etag = catalog_manifest_etag(manifest)
+    if request.if_none_match.contains(etag):
+        response = make_response("", 304)
+    else:
+        response = jsonify(manifest)
+    response.set_etag(etag)
+    response.headers["Cache-Control"] = "no-cache"
+    return response
 
 
 @app.teardown_appcontext

--- a/server/app/catalog_manifest.py
+++ b/server/app/catalog_manifest.py
@@ -1,0 +1,17 @@
+"""Format the persisted item/set catalog revision for clients."""
+
+
+CATALOG_SCHEMA_VERSION = 2
+
+
+def catalog_manifest(revision):
+    """Return the stable wire representation for a database catalog revision."""
+    return {
+        "schemaVersion": CATALOG_SCHEMA_VERSION,
+        "version": str(revision),
+    }
+
+
+def catalog_manifest_etag(manifest):
+    """Include both wire schema and data revision in HTTP cache validation."""
+    return "catalog-v{schemaVersion}-r{version}".format(**manifest)

--- a/server/app/catalog_revision.py
+++ b/server/app/catalog_revision.py
@@ -1,0 +1,40 @@
+"""Transactional access to the singleton item/set catalog revision."""
+
+from app.database.model_catalog_revision import ModelCatalogRevision
+
+
+CATALOG_REVISION_ID = 1
+
+
+def get_catalog_revision(db_session):
+    """Read the current revision without retaining it in process memory."""
+    row = (
+        db_session.query(ModelCatalogRevision)
+        .filter(ModelCatalogRevision.id == CATALOG_REVISION_ID)
+        .one()
+    )
+    return row.revision
+
+
+def advance_catalog_revision(db_session):
+    """Increment and return the revision in the caller's transaction.
+
+    The row lock prevents concurrent catalog syncs from losing an increment. The
+    caller owns commit/rollback, keeping the revision atomic with catalog writes.
+    """
+    row = (
+        db_session.query(ModelCatalogRevision)
+        .filter(ModelCatalogRevision.id == CATALOG_REVISION_ID)
+        .with_for_update()
+        .one()
+    )
+    row.revision += 1
+    db_session.flush()
+    return row.revision
+
+
+def advance_catalog_revision_for_changes(db_session, *change_groups):
+    """Advance once when at least one supplied result collection has changes."""
+    if any(change_groups):
+        return advance_catalog_revision(db_session)
+    return None

--- a/server/app/database/model_catalog_revision.py
+++ b/server/app/database/model_catalog_revision.py
@@ -1,0 +1,15 @@
+from sqlalchemy import BigInteger, CheckConstraint, Column, SmallInteger
+
+from .base import Base
+
+
+class ModelCatalogRevision(Base):
+    """Singleton revision for the client-visible item and set catalog."""
+
+    __tablename__ = "catalog_revision"
+    __table_args__ = (
+        CheckConstraint("id = 1", name="catalog_revision_singleton"),
+    )
+
+    id = Column(SmallInteger, primary_key=True, nullable=False)
+    revision = Column(BigInteger, nullable=False)

--- a/server/app/migrations/versions/39dc1a102438_add_catalog_revision.py
+++ b/server/app/migrations/versions/39dc1a102438_add_catalog_revision.py
@@ -1,0 +1,30 @@
+"""Add catalog revision singleton
+
+Revision ID: 39dc1a102438
+Revises: 1cb498f44c5b
+Create Date: 2026-07-14
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "39dc1a102438"
+down_revision = "1cb498f44c5b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    catalog_revision = op.create_table(
+        "catalog_revision",
+        sa.Column("id", sa.SmallInteger(), nullable=False),
+        sa.Column("revision", sa.BigInteger(), nullable=False),
+        sa.CheckConstraint("id = 1", name=op.f("ck_catalog_revision_catalog_revision_singleton")),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_catalog_revision")),
+    )
+    op.bulk_insert(catalog_revision, [{"id": 1, "revision": 1}])
+
+
+def downgrade():
+    op.drop_table("catalog_revision")

--- a/server/oneoff/add_item_type_to_slot.py
+++ b/server/oneoff/add_item_type_to_slot.py
@@ -5,6 +5,7 @@ from app.database.model_item_type import ModelItemType
 from app.database.model_item_type_translation import ModelItemTypeTranslation
 from app.database.model_item_slot import ModelItemSlot
 from app.database.model_item_slot_translation import ModelItemSlotTranslation
+from app.catalog_revision import advance_catalog_revision
 
 app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -17,6 +18,7 @@ def add_item_type_to_slot():
         data = json.load(file)
 
         with session_scope() as db_session:
+            catalog_changed = False
             for record in data:
                 slots = (
                     db_session.query(ModelItemSlot)
@@ -49,11 +51,14 @@ def add_item_type_to_slot():
                         )
                         if not relationship_exists:
                             slot.item_types.append(item_type)
+                            catalog_changed = True
                             print(
                                 "{} type added to {} slot".format(
                                     type_en_name, record["name"]["en"]
                                 )
                             )
+            if catalog_changed:
+                advance_catalog_revision(db_session)
 
 
 if __name__ == "__main__":

--- a/server/oneoff/sync_buff.py
+++ b/server/oneoff/sync_buff.py
@@ -9,6 +9,7 @@ from app.database.model_item_translation import ModelItemTranslation
 from app.database.model_buff import ModelBuff
 from app.database.model_item import ModelItem
 from oneoff.enums import to_stat_enum
+from app.catalog_revision import advance_catalog_revision
 
 root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -22,6 +23,8 @@ def add_item_buffs(db_session, item_id, record):
             max_stacks=buff["maxStacks"],
         )
         db_session.add(buff_object)
+    if record["buffs"]:
+        advance_catalog_revision(db_session)
 
 
 def update_item_buffs(db_session, item_id, record):
@@ -34,6 +37,7 @@ def update_item_buffs(db_session, item_id, record):
             max_stacks=buff["maxStacks"],
         )
         db_session.add(buff_object)
+    advance_catalog_revision(db_session)
 
 
 def add_spell_buff_for_level(db_session, spell_stat_id, buff_data):

--- a/server/oneoff/sync_class.py
+++ b/server/oneoff/sync_class.py
@@ -21,9 +21,11 @@ app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def wipeSpellsAndBuffs():
+    db.session.query(ModelBuff).filter(
+        ModelBuff.spell_stat_id.isnot(None)
+    ).delete(synchronize_session=False)
     db.session.query(ModelSpell).delete()
     db.session.query(ModelSpellVariantPair).delete()
-    db.session.query(ModelBuff).delete()
     db.session.flush()
 
 
@@ -112,7 +114,7 @@ def add_buffs():
                     .item_id
                 )
 
-                oneoff.sync_buff.add_item_buffs(db_session, item_id, item)
+                oneoff.sync_buff.update_item_buffs(db_session, item_id, item)
 
 
 add_class_to_classes()

--- a/server/oneoff/sync_item.py
+++ b/server/oneoff/sync_item.py
@@ -21,6 +21,7 @@ import json
 import os
 from sqlalchemy import or_
 from app import session_scope
+from app.catalog_revision import advance_catalog_revision_for_changes
 from app.database.model_set import ModelSet
 from app.database.model_item import ModelItem
 from app.database.model_item_stat import ModelItemStat
@@ -399,7 +400,7 @@ def preview_changes(db_session, all_items, all_item_ids, operation_type):
     return items_to_create, items_to_update, items_to_delete
 
 
-def execute_upsert_all(db_session, all_items):
+def execute_upsert_all(db_session, all_items, advance_revision=True):
     """Execute upsert all operation."""
     created_items = []
     updated_items = []
@@ -412,11 +413,12 @@ def execute_upsert_all(db_session, all_items):
             item_name = record["name"]["en"]
             
             try:
-                result = update_or_create_item(
-                    db_session,
-                    item_id,
-                    record,
-                )
+                with db_session.begin_nested():
+                    result = update_or_create_item(
+                        db_session,
+                        item_id,
+                        record,
+                    )
                 
                 if result is True:
                     created_items.append(f"[{item_id}]: {item_name}")
@@ -430,13 +432,20 @@ def execute_upsert_all(db_session, all_items):
                 print(f"Error processing item {error_msg}")
                 # Continue processing other items
     
+    if advance_revision:
+        advance_catalog_revision_for_changes(
+            db_session, created_items, updated_items
+        )
+
     return created_items, updated_items, skipped_items, errored_items
 
 
 def execute_sync_all(db_session, all_items, all_item_ids):
     """Execute sync all operation (upsert + delete)."""
     # First do upsert
-    created_items, updated_items, skipped_items, errored_items = execute_upsert_all(db_session, all_items)
+    created_items, updated_items, skipped_items, errored_items = execute_upsert_all(
+        db_session, all_items, advance_revision=False
+    )
     
     # Then delete items not in input files
     items_to_delete = get_items_to_delete(db_session, all_item_ids, "all")
@@ -444,6 +453,10 @@ def execute_sync_all(db_session, all_items, all_item_ids):
     
     if items_to_delete:
         deleted_items = delete_items_not_in_file(db_session, items_to_delete, "all")
+
+    advance_catalog_revision_for_changes(
+        db_session, created_items, updated_items, deleted_items
+    )
     
     return created_items, updated_items, skipped_items, errored_items, deleted_items
 
@@ -490,11 +503,14 @@ def execute_individual_upsert(db_session, all_items):
             item_name = record["name"]["en"]
             
             try:
-                result = update_or_create_item(db_session, item_id, record)
+                with db_session.begin_nested():
+                    result = update_or_create_item(db_session, item_id, record)
                 
                 if result is True:
+                    advance_catalog_revision_for_changes(db_session, [item_id])
                     return [f"[{item_id}]: {item_name}"], [], [], []
                 elif result is False:
+                    advance_catalog_revision_for_changes(db_session, [item_id])
                     return [], [f"[{item_id}]: {item_name}"], [], []
                 elif result is None:
                     return [], [], [f"[{item_id}]: {item_name}"], []

--- a/server/oneoff/sync_item_type.py
+++ b/server/oneoff/sync_item_type.py
@@ -5,6 +5,7 @@ import os
 from app import session_scope
 from app.database.model_item_type import ModelItemType
 from app.database.model_item_type_translation import ModelItemTypeTranslation
+from app.catalog_revision import advance_catalog_revision
 
 app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -59,9 +60,12 @@ def sync_item_type():
                         recreate_item_type_translations(
                             db_session, record["en"], record
                         )
+                    if data:
+                        advance_catalog_revision(db_session)
                 elif item_name in name_to_record_map:
                     record = name_to_record_map[item_name]
                     recreate_item_type_translations(db_session, item_name, record)
+                    advance_catalog_revision(db_session)
 
 
 if __name__ == "__main__":

--- a/server/oneoff/sync_name.py
+++ b/server/oneoff/sync_name.py
@@ -7,6 +7,7 @@ from app.database.model_item_translation import ModelItemTranslation
 from app.database.model_set_translation import ModelSetTranslation
 from app.database.model_spell_translation import ModelSpellTranslation
 from oneoff.sync_item import allowed_file_names as item_file_names
+from app.catalog_revision import advance_catalog_revision
 
 app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -107,6 +108,9 @@ def update_name(db_session, name_to_record_map, file_name, old_name, new_name):
                     db_session.add(spell_translation)
         else:
             raise ValueError("Invalid file name")
+
+        if file_name in item_file_names or file_name == "sets":
+            advance_catalog_revision(db_session)
 
 
 def get_name_to_record_map(file_name):

--- a/server/oneoff/sync_set.py
+++ b/server/oneoff/sync_set.py
@@ -20,6 +20,7 @@ import json
 import os
 from sqlalchemy import or_
 from app import session_scope
+from app.catalog_revision import advance_catalog_revision_for_changes
 from app.database.model_set import ModelSet
 from app.database.model_set_translation import ModelSetTranslation
 from app.database.model_set_bonus import ModelSetBonus
@@ -236,7 +237,7 @@ def preview_changes(db_session, all_sets, all_set_ids, operation_type):
     return sets_to_create, sets_to_update, sets_to_delete
 
 
-def execute_upsert_all(db_session, all_sets):
+def execute_upsert_all(db_session, all_sets, advance_revision=True):
     """Execute upsert all operation."""
     created_sets = []
     updated_sets = []
@@ -248,11 +249,12 @@ def execute_upsert_all(db_session, all_sets):
         set_name = record["name"]["en"]
         
         try:
-            result = update_or_create_set(
-                db_session,
-                set_id,
-                record,
-            )
+            with db_session.begin_nested():
+                result = update_or_create_set(
+                    db_session,
+                    set_id,
+                    record,
+                )
             
             if result is True:
                 created_sets.append(f"[{set_id}]: {set_name}")
@@ -266,13 +268,20 @@ def execute_upsert_all(db_session, all_sets):
             print(f"Error processing set {error_msg}")
             # Continue processing other sets
     
+    if advance_revision:
+        advance_catalog_revision_for_changes(
+            db_session, created_sets, updated_sets
+        )
+
     return created_sets, updated_sets, skipped_sets, errored_sets
 
 
 def execute_sync_all(db_session, all_sets, all_set_ids):
     """Execute sync all operation (upsert + delete)."""
     # First do upsert
-    created_sets, updated_sets, skipped_sets, errored_sets = execute_upsert_all(db_session, all_sets)
+    created_sets, updated_sets, skipped_sets, errored_sets = execute_upsert_all(
+        db_session, all_sets, advance_revision=False
+    )
     
     # Then delete sets not in input file
     sets_to_delete = get_sets_to_delete(db_session, all_set_ids)
@@ -280,6 +289,10 @@ def execute_sync_all(db_session, all_sets, all_set_ids):
     
     if sets_to_delete:
         deleted_sets = delete_sets_not_in_file(db_session, sets_to_delete)
+
+    advance_catalog_revision_for_changes(
+        db_session, created_sets, updated_sets, deleted_sets
+    )
     
     return created_sets, updated_sets, skipped_sets, errored_sets, deleted_sets
 
@@ -304,11 +317,14 @@ def execute_individual_upsert(db_session, all_sets):
             set_name = record["name"]["en"]
             
             try:
-                result = update_or_create_set(db_session, set_id, record)
+                with db_session.begin_nested():
+                    result = update_or_create_set(db_session, set_id, record)
                 
                 if result is True:
+                    advance_catalog_revision_for_changes(db_session, [set_id])
                     return [f"[{set_id}]: {set_name}"], [], [], []
                 elif result is False:
+                    advance_catalog_revision_for_changes(db_session, [set_id])
                     return [], [f"[{set_id}]: {set_name}"], [], []
                 elif result is None:
                     return [], [], [f"[{set_id}]: {set_name}"], []

--- a/server/oneoff/update_image_urls.py
+++ b/server/oneoff/update_image_urls.py
@@ -11,6 +11,7 @@ from app.database.model_set import ModelSet
 from app.database.model_item import ModelItem
 from app.database.model_spell import ModelSpell
 from app.database.model_item_slot import ModelItemSlot
+from app.catalog_revision import advance_catalog_revision
 
 app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -21,14 +22,18 @@ def update_item_urls_in_db():
     mappings = []
 
     for item in db.session.query(ModelItem):
+        image_url = url_base + re.search(r"\d+\.png", item.image_url)[0]
+        if image_url == item.image_url:
+            continue
         info = {
             "uuid": item.uuid,
-            "image_url": url_base + re.search("\d+\.png", item.image_url)[0],
+            "image_url": image_url,
         }
         mappings.append(info)
 
-    db.session.bulk_update_mappings(ModelItem, mappings)
-    db.session.flush()
+    if mappings:
+        db.session.bulk_update_mappings(ModelItem, mappings)
+        advance_catalog_revision(db.session)
     db.session.commit()
 
 

--- a/server/test_catalog_manifest.py
+++ b/server/test_catalog_manifest.py
@@ -1,0 +1,48 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+module_path = Path(__file__).parent / "app" / "catalog_manifest.py"
+spec = importlib.util.spec_from_file_location("catalog_manifest", module_path)
+catalog_manifest_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(catalog_manifest_module)
+
+
+class CatalogManifestTest(unittest.TestCase):
+    def test_formats_database_revision_for_wire_contract(self):
+        self.assertEqual(
+            catalog_manifest_module.catalog_manifest(42),
+            {"schemaVersion": 2, "version": "42"},
+        )
+
+    def test_formatter_has_no_cached_database_state(self):
+        self.assertEqual(
+            catalog_manifest_module.catalog_manifest(7)["version"], "7"
+        )
+        self.assertEqual(
+            catalog_manifest_module.catalog_manifest(8)["version"], "8"
+        )
+
+    def test_etag_changes_for_schema_or_database_revision(self):
+        first = {"schemaVersion": 2, "version": "7"}
+        self.assertEqual(
+            catalog_manifest_module.catalog_manifest_etag(first),
+            "catalog-v2-r7",
+        )
+        self.assertNotEqual(
+            catalog_manifest_module.catalog_manifest_etag(first),
+            catalog_manifest_module.catalog_manifest_etag(
+                {"schemaVersion": 3, "version": "7"}
+            ),
+        )
+        self.assertNotEqual(
+            catalog_manifest_module.catalog_manifest_etag(first),
+            catalog_manifest_module.catalog_manifest_etag(
+                {"schemaVersion": 2, "version": "8"}
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test_catalog_revision.py
+++ b/server/test_catalog_revision.py
@@ -1,0 +1,117 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+
+
+class ComparableField:
+    def __eq__(self, other):
+        return ("id", other)
+
+
+class StubCatalogRevision:
+    id = ComparableField()
+
+
+model_module = types.ModuleType("app.database.model_catalog_revision")
+model_module.ModelCatalogRevision = StubCatalogRevision
+stubbed_module_names = (
+    "app",
+    "app.database",
+    "app.database.model_catalog_revision",
+)
+previous_modules = {
+    name: sys.modules.get(name) for name in stubbed_module_names
+}
+try:
+    sys.modules["app"] = types.ModuleType("app")
+    sys.modules["app.database"] = types.ModuleType("app.database")
+    sys.modules["app.database.model_catalog_revision"] = model_module
+
+    module_path = Path(__file__).parent / "app" / "catalog_revision.py"
+    spec = importlib.util.spec_from_file_location("catalog_revision", module_path)
+    catalog_revision_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(catalog_revision_module)
+finally:
+    for module_name, previous_module in previous_modules.items():
+        if previous_module is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous_module
+
+
+class RevisionRow:
+    def __init__(self, revision):
+        self.revision = revision
+
+
+class FakeQuery:
+    def __init__(self, row):
+        self.row = row
+        self.locked = False
+        self.filter_expression = None
+
+    def filter(self, expression):
+        self.filter_expression = expression
+        return self
+
+    def with_for_update(self):
+        self.locked = True
+        return self
+
+    def one(self):
+        return self.row
+
+
+class FakeSession:
+    def __init__(self, revision):
+        self.row = RevisionRow(revision)
+        self.query_object = FakeQuery(self.row)
+        self.flush_count = 0
+
+    def query(self, model):
+        self.queried_model = model
+        return self.query_object
+
+    def flush(self):
+        self.flush_count += 1
+
+
+class CatalogRevisionTest(unittest.TestCase):
+    def test_reads_current_revision_each_time(self):
+        session = FakeSession(4)
+        self.assertEqual(
+            catalog_revision_module.get_catalog_revision(session), 4
+        )
+        self.assertFalse(session.query_object.locked)
+
+    def test_advance_locks_flushes_and_returns_incremented_revision(self):
+        session = FakeSession(9)
+        self.assertEqual(
+            catalog_revision_module.advance_catalog_revision(session), 10
+        )
+        self.assertEqual(session.row.revision, 10)
+        self.assertTrue(session.query_object.locked)
+        self.assertEqual(session.flush_count, 1)
+
+    def test_change_guard_does_not_advance_for_skips_or_errors_only(self):
+        session = FakeSession(3)
+        result = catalog_revision_module.advance_catalog_revision_for_changes(
+            session, [], []
+        )
+        self.assertIsNone(result)
+        self.assertEqual(session.row.revision, 3)
+        self.assertEqual(session.flush_count, 0)
+
+    def test_change_guard_advances_once_for_any_number_of_change_groups(self):
+        session = FakeSession(3)
+        result = catalog_revision_module.advance_catalog_revision_for_changes(
+            session, ["created"], ["updated"], ["deleted"]
+        )
+        self.assertEqual(result, 4)
+        self.assertEqual(session.flush_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/test_catalog_sync_revision.py
+++ b/server/test_catalog_sync_revision.py
@@ -1,0 +1,412 @@
+import ast
+from contextlib import contextmanager
+from pathlib import Path
+import unittest
+
+
+SERVER_ROOT = Path(__file__).parent
+
+
+class FakeSavepoint:
+    def __init__(self, session):
+        self.session = session
+        self.snapshot = list(session.mutations)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, _exception, _traceback):
+        if exception_type is not None:
+            self.session.mutations[:] = self.snapshot
+        return False
+
+
+class FakeSyncSession:
+    def __init__(self):
+        self.mutations = []
+
+    def begin_nested(self):
+        return FakeSavepoint(self)
+
+
+def load_functions(relative_path, function_names, namespace):
+    source = (SERVER_ROOT / relative_path).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    selected = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in function_names
+    ]
+    exec(compile(ast.Module(body=selected, type_ignores=[]), str(relative_path), "exec"), namespace)
+    return namespace
+
+
+class CatalogSyncRevisionTest(unittest.TestCase):
+    def _revision_guard(self, advances):
+        def advance_for_changes(_session, *groups):
+            if any(groups):
+                advances.append(groups)
+
+        return advance_for_changes
+
+    def test_item_upsert_advances_for_changes_not_skips_or_errors(self):
+        advances = []
+
+        def update_item(_session, item_id, _record):
+            if item_id == "error":
+                raise ValueError("invalid")
+            return {"created": True, "updated": False, "skipped": None}[item_id]
+
+        namespace = load_functions(
+            Path("oneoff/sync_item.py"),
+            {"execute_upsert_all"},
+            {
+                "update_or_create_item": update_item,
+                "advance_catalog_revision_for_changes": self._revision_guard(advances),
+            },
+        )
+        records = {
+            "items": [
+                {"dofusID": result, "name": {"en": result}}
+                for result in ("created", "updated", "skipped", "error")
+            ]
+        }
+        result = namespace["execute_upsert_all"](FakeSyncSession(), records)
+        self.assertEqual([len(group) for group in result], [1, 1, 1, 1])
+        self.assertEqual(len(advances), 1)
+
+        advances.clear()
+        namespace["execute_upsert_all"](
+            FakeSyncSession(),
+            {"items": records["items"][2:]},
+        )
+        self.assertEqual(advances, [])
+
+    def test_item_sync_advances_once_for_upserts_and_deletes(self):
+        advances = []
+        namespace = load_functions(
+            Path("oneoff/sync_item.py"),
+            {"execute_upsert_all", "execute_sync_all"},
+            {
+                "update_or_create_item": lambda _session, _item_id, _record: True,
+                "get_items_to_delete": lambda _session, _ids, _scope: [object()],
+                "delete_items_not_in_file": lambda _session, _rows, _scope: ["deleted"],
+                "advance_catalog_revision_for_changes": self._revision_guard(advances),
+            },
+        )
+        namespace["execute_sync_all"](
+            FakeSyncSession(),
+            {"items": [{"dofusID": "1", "name": {"en": "One"}}]},
+            {"1"},
+        )
+        self.assertEqual(len(advances), 1)
+
+    def test_set_sync_advances_once_and_noop_does_not_advance(self):
+        advances = []
+        namespace = load_functions(
+            Path("oneoff/sync_set.py"),
+            {"execute_upsert_all", "execute_sync_all"},
+            {
+                "update_or_create_set": lambda _session, _set_id, _record: False,
+                "get_sets_to_delete": lambda _session, _ids: [],
+                "delete_sets_not_in_file": lambda _session, _rows: [],
+                "advance_catalog_revision_for_changes": self._revision_guard(advances),
+            },
+        )
+        namespace["execute_sync_all"](
+            FakeSyncSession(),
+            [{"id": "1", "name": {"en": "One"}}],
+            {"1"},
+        )
+        self.assertEqual(len(advances), 1)
+
+        advances.clear()
+        namespace["execute_sync_all"](FakeSyncSession(), [], set())
+        self.assertEqual(advances, [])
+
+    def test_item_savepoint_keeps_success_and_rolls_back_later_error(self):
+        advances = []
+
+        def mutate_item(session, item_id, _record):
+            session.mutations.append(item_id)
+            if item_id == "error":
+                session.mutations.append("partial-error-write")
+                raise ValueError("invalid after mutation")
+            return True
+
+        namespace = load_functions(
+            Path("oneoff/sync_item.py"),
+            {"execute_upsert_all"},
+            {
+                "update_or_create_item": mutate_item,
+                "advance_catalog_revision_for_changes": self._revision_guard(advances),
+            },
+        )
+        session = FakeSyncSession()
+        result = namespace["execute_upsert_all"](
+            session,
+            {
+                "items": [
+                    {"dofusID": "success", "name": {"en": "Success"}},
+                    {"dofusID": "error", "name": {"en": "Error"}},
+                ]
+            },
+        )
+        self.assertEqual(session.mutations, ["success"])
+        self.assertEqual([len(group) for group in result], [1, 0, 0, 1])
+        self.assertEqual(len(advances), 1)
+
+    def test_set_savepoint_rolls_back_error_only_without_revision(self):
+        advances = []
+
+        def mutate_set(session, set_id, _record):
+            session.mutations.extend([set_id, "partial-error-write"])
+            raise ValueError("invalid after mutation")
+
+        namespace = load_functions(
+            Path("oneoff/sync_set.py"),
+            {"execute_upsert_all"},
+            {
+                "update_or_create_set": mutate_set,
+                "advance_catalog_revision_for_changes": self._revision_guard(advances),
+            },
+        )
+        session = FakeSyncSession()
+        result = namespace["execute_upsert_all"](
+            session,
+            [{"id": "error", "name": {"en": "Error"}}],
+        )
+        self.assertEqual(session.mutations, [])
+        self.assertEqual([len(group) for group in result], [0, 0, 0, 1])
+        self.assertEqual(advances, [])
+
+    def test_low_level_item_buff_paths_advance_for_all_callers(self):
+        advances = []
+
+        class Field:
+            def __eq__(self, other):
+                return other
+
+        class Buff:
+            item_id = Field()
+
+            def __init__(self, **values):
+                self.values = values
+
+        class Query:
+            def filter(self, _expression):
+                return self
+
+            def delete(self):
+                return 1
+
+        class Session:
+            def __init__(self):
+                self.added = []
+
+            def add(self, value):
+                self.added.append(value)
+
+            def query(self, _model):
+                return Query()
+
+        namespace = load_functions(
+            Path("oneoff/sync_buff.py"),
+            {"add_item_buffs", "update_item_buffs"},
+            {
+                "ModelBuff": Buff,
+                "to_stat_enum": {"Power": "power"},
+                "advance_catalog_revision": lambda _session: advances.append(True),
+            },
+        )
+        record = {
+            "buffs": [
+                {"stat": "Power", "incrementBy": 10, "maxStacks": 2}
+            ]
+        }
+        session = Session()
+        namespace["add_item_buffs"](session, "item-1", record)
+        namespace["update_item_buffs"](session, "item-1", record)
+        self.assertEqual(len(advances), 2)
+
+        namespace["add_item_buffs"](session, "item-1", {"buffs": []})
+        self.assertEqual(len(advances), 2)
+
+    def test_item_image_url_update_advances_only_for_actual_changes(self):
+        events = []
+
+        class Item:
+            pass
+
+        class ItemRecord:
+            def __init__(self, uuid, image_url):
+                self.uuid = uuid
+                self.image_url = image_url
+
+        class Session:
+            def __init__(self, records):
+                self.records = records
+
+            def query(self, model):
+                self.queried_model = model
+                return self.records
+
+            def bulk_update_mappings(self, model, mappings):
+                events.append(("update", model, mappings))
+
+            def commit(self):
+                events.append(("commit",))
+
+        class Db:
+            def __init__(self, records):
+                self.session = Session(records)
+
+        namespace = load_functions(
+            Path("oneoff/update_image_urls.py"),
+            {"update_item_urls_in_db"},
+            {
+                "db": Db(
+                    [
+                        ItemRecord("unchanged", "item/1.png"),
+                        ItemRecord("changed", "https://old.example/2.png"),
+                    ]
+                ),
+                "ModelItem": Item,
+                "re": __import__("re"),
+                "advance_catalog_revision": lambda _session: events.append(
+                    ("revision",)
+                ),
+            },
+        )
+        namespace["update_item_urls_in_db"]()
+
+        self.assertEqual(
+            events,
+            [
+                (
+                    "update",
+                    Item,
+                    [{"uuid": "changed", "image_url": "item/2.png"}],
+                ),
+                ("revision",),
+                ("commit",),
+            ],
+        )
+
+        events.clear()
+        namespace["db"] = Db([ItemRecord("unchanged", "item/1.png")])
+        namespace["update_item_urls_in_db"]()
+        self.assertEqual(events, [("commit",)])
+
+    def test_class_wipe_deletes_only_spell_buffs(self):
+        deletes = []
+
+        class Spell:
+            pass
+
+        class SpellVariantPair:
+            pass
+
+        class SpellStatId:
+            def isnot(self, value):
+                return ("spell-stat-is-not", value)
+
+        class Buff:
+            spell_stat_id = SpellStatId()
+
+        class Query:
+            def __init__(self, model):
+                self.model = model
+                self.expression = None
+
+            def filter(self, expression):
+                self.expression = expression
+                return self
+
+            def delete(self, **options):
+                deletes.append((self.model, self.expression, options))
+
+        class Session:
+            def query(self, model):
+                return Query(model)
+
+            def flush(self):
+                deletes.append(("flush",))
+
+        namespace = load_functions(
+            Path("oneoff/sync_class.py"),
+            {"wipeSpellsAndBuffs"},
+            {
+                "db": type("Db", (), {"session": Session()})(),
+                "ModelBuff": Buff,
+                "ModelSpell": Spell,
+                "ModelSpellVariantPair": SpellVariantPair,
+            },
+        )
+        namespace["wipeSpellsAndBuffs"]()
+
+        self.assertEqual(
+            deletes[0],
+            (Buff, ("spell-stat-is-not", None), {"synchronize_session": False}),
+        )
+        self.assertNotIn((Buff, None, {}), deletes)
+
+    def test_class_buff_sync_replaces_each_items_buffs(self):
+        replacements = []
+        item_record = {"name": "Crimson Dofus", "buffs": []}
+
+        class TranslationResult:
+            item_id = "item-1"
+
+        class Query:
+            def filter_by(self, **_filters):
+                return self
+
+            def one(self):
+                return TranslationResult()
+
+        class Session:
+            def query(self, _model):
+                return Query()
+
+        @contextmanager
+        def session_scope():
+            yield Session()
+
+        class Json:
+            @staticmethod
+            def load(_file):
+                return {"spells": {}, "items": [item_record]}
+
+        class SyncBuff:
+            @staticmethod
+            def update_item_buffs(session, item_id, record):
+                replacements.append((session, item_id, record))
+
+        namespace = load_functions(
+            Path("oneoff/sync_class.py"),
+            {"add_buffs"},
+            {
+                "open": lambda *_args, **_kwargs: __import__("contextlib").nullcontext(
+                    object()
+                ),
+                "os": __import__("os"),
+                "app_root": str(SERVER_ROOT),
+                "json": Json,
+                "session_scope": session_scope,
+                "ModelItemTranslation": object(),
+                "oneoff": type(
+                    "Oneoff",
+                    (),
+                    {"sync_buff": SyncBuff},
+                )(),
+            },
+        )
+        namespace["add_buffs"]()
+
+        self.assertEqual(len(replacements), 1)
+        self.assertEqual(replacements[0][1:], ("item-1", item_record))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a database-backed singleton revision for the public item/set catalog
- expose an ETag-aware catalog manifest endpoint
- advance the revision transactionally from supported item, set, type, name, buff, and image sync workflows
- keep per-record sync failures isolated with nested transactions

## Validation
- `python -m unittest test_catalog_manifest.py test_catalog_revision.py test_catalog_sync_revision.py`
- Python compilation for revision and sync modules

## Integration notes
- `database_setup.py` remains bootstrap-only; deprecated one-off translation scripts are not treated as live sync APIs
- Build Discovery's in-flight migration `395c1a102439` currently shares parent `1cb498f44c5b` with this migration. Before both streams deploy together, rebase one migration linearly or add an Alembic merge revision.
- When reconciling Build Discovery's sync changes, retain both the transactional revision update and its post-commit discovery-index regeneration.
