### PR TITLE
Expose multilingual catalog search names

### DIFF
--- a/client/__generated__/globalTypes.ts
+++ b/client/__generated__/globalTypes.ts
@@ -289,6 +289,7 @@ export type Item = GlobalNode & {
   itemTypeId: Scalars['String']['output'];
   level: Scalars['Int']['output'];
   name: Scalars['String']['output'];
+  searchNames: Array<Scalars['String']['output']>;
   set: Maybe<Set>;
   setId: Maybe<Scalars['String']['output']>;
   stats: Array<ItemStat>;
@@ -665,6 +666,7 @@ export type Set = GlobalNode & {
   id: Scalars['UUID']['output'];
   items: Array<Item>;
   name: Scalars['String']['output'];
+  searchNames: Array<Scalars['String']['output']>;
   uuid: Scalars['String']['output'];
 };
 

--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -131,12 +131,14 @@ cache = redis.Redis(
 from app.schema import schema
 from app.loaders import (
     ItemNameLoader,
+    AllItemNamesLoader,
     ItemStatsLoader,
     ItemStatTranslationLoader,
     SetLoader,
     SetBonusLoader,
     SetBonusTranslationLoader,
     SetTranslationLoader,
+    AllSetNamesLoader,
     WeaponEffectLoader,
     WeaponStatLoader,
     SpellBuffLoader,
@@ -172,12 +174,14 @@ from app.loaders import (
 def construct_dataloaders():
     g.dataloaders = {
         "item_name_loader": ItemNameLoader(),
+        "all_item_names_loader": AllItemNamesLoader(),
         "item_stats_loader": ItemStatsLoader(),
         "item_stat_translation_loader": ItemStatTranslationLoader(),
         "set_loader": SetLoader(),
         "set_bonus_loader": SetBonusLoader(),
         "set_bonus_translation_loader": SetBonusTranslationLoader(),
         "set_translation_loader": SetTranslationLoader(),
+        "all_set_names_loader": AllSetNamesLoader(),
         "weapon_stat_loader": WeaponStatLoader(),
         "weapon_effect_loader": WeaponEffectLoader(),
         "spell_buff_loader": SpellBuffLoader(),

--- a/server/app/loaders.py
+++ b/server/app/loaders.py
@@ -497,6 +497,24 @@ class ItemNameLoader(DataLoader):
         return load_item_names(item_ids)
 
 
+def load_all_item_names(item_ids):
+    names_by_item_id = defaultdict(list)
+    for translation in (
+        db.session.query(ModelItemTranslation)
+        .filter(ModelItemTranslation.item_id.in_(item_ids))
+        .order_by(ModelItemTranslation.item_id, ModelItemTranslation.locale)
+    ):
+        names_by_item_id[translation.item_id].append(translation.name)
+    return Promise.resolve(
+        [names_by_item_id.get(item_id, []) for item_id in item_ids]
+    )
+
+
+class AllItemNamesLoader(DataLoader):
+    def batch_load_fn(self, item_ids):
+        return load_all_item_names(item_ids)
+
+
 # @cache_region.cache_on_arguments()
 def load_sets(set_ids):
     sets = {
@@ -567,6 +585,22 @@ def load_set_translations(set_ids):
 class SetTranslationLoader(DataLoader):
     def batch_load_fn(self, set_ids):
         return load_set_translations(set_ids)
+
+
+def load_all_set_names(set_ids):
+    names_by_set_id = defaultdict(list)
+    for translation in (
+        db.session.query(ModelSetTranslation)
+        .filter(ModelSetTranslation.set_id.in_(set_ids))
+        .order_by(ModelSetTranslation.set_id, ModelSetTranslation.locale)
+    ):
+        names_by_set_id[translation.set_id].append(translation.name)
+    return Promise.resolve([names_by_set_id.get(set_id, []) for set_id in set_ids])
+
+
+class AllSetNamesLoader(DataLoader):
+    def batch_load_fn(self, set_ids):
+        return load_all_set_names(set_ids)
 
 
 # @cache_region.cache_on_arguments()

--- a/server/app/schema.py
+++ b/server/app/schema.py
@@ -236,6 +236,14 @@ class Item(SQLAlchemyObjectType):
 
     name = graphene.String(required=True)
 
+    # Search-only names across every supported translation. `name` remains the
+    # request locale's display value.
+    search_names = graphene.NonNull(graphene.List(graphene.NonNull(graphene.String)))
+
+    @tracer.wrap(name="Item.resolve_search_names")
+    def resolve_search_names(self, info):
+        return g.dataloaders.get("all_item_names_loader").load(self.uuid)
+
     @tracer.wrap(name="Item.resolve_name")
     def resolve_name(self, info):
         return g.dataloaders.get("item_name_loader").load(self.uuid)
@@ -300,6 +308,14 @@ class Set(SQLAlchemyObjectType):
         return g.dataloaders.get("set_bonus_loader").load(self.uuid)
 
     name = graphene.String(required=True)
+
+    # Search-only names across every supported translation. `name` remains the
+    # request locale's display value.
+    search_names = graphene.NonNull(graphene.List(graphene.NonNull(graphene.String)))
+
+    @tracer.wrap(name="Set.resolve_search_names")
+    def resolve_search_names(self, info):
+        return g.dataloaders.get("all_set_names_loader").load(self.uuid)
 
     @tracer.wrap(name="Set.resolve_name")
     def resolve_name(self, info):

--- a/server/test_multilingual_search_names.py
+++ b/server/test_multilingual_search_names.py
@@ -1,0 +1,172 @@
+import ast
+from collections import defaultdict
+from pathlib import Path
+import unittest
+
+
+SERVER_ROOT = Path(__file__).parent
+
+
+class ImmediatePromise:
+    @staticmethod
+    def resolve(value):
+        return value
+
+
+class QueryField:
+    def in_(self, values):
+        return ("in", tuple(values))
+
+
+class TranslationModel:
+    item_id = QueryField()
+    set_id = QueryField()
+    locale = QueryField()
+
+
+class Translation:
+    def __init__(self, *, item_id=None, set_id=None, locale, name):
+        self.item_id = item_id
+        self.set_id = set_id
+        self.locale = locale
+        self.name = name
+
+
+class FakeQuery:
+    def __init__(self, rows):
+        self.rows = rows
+        self.filter_expression = None
+        self.order_fields = None
+
+    def filter(self, expression):
+        self.filter_expression = expression
+        return self
+
+    def order_by(self, *fields):
+        self.order_fields = fields
+        return self
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+class FakeSession:
+    def __init__(self, rows):
+        self.query_object = FakeQuery(rows)
+        self.queried_model = None
+
+    def query(self, model):
+        self.queried_model = model
+        return self.query_object
+
+
+class FakeDB:
+    def __init__(self, rows):
+        self.session = FakeSession(rows)
+
+
+def load_function(function_name, namespace):
+    relative_path = Path("app/loaders.py")
+    source = (SERVER_ROOT / relative_path).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    selected = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    ]
+    if len(selected) != 1:
+        raise AssertionError(f"Expected one {function_name} function")
+    exec(
+        compile(ast.Module(body=selected, type_ignores=[]), str(relative_path), "exec"),
+        namespace,
+    )
+    return namespace[function_name]
+
+
+def resolver_loader_name(type_name, resolver_name):
+    schema_path = SERVER_ROOT / "app/schema.py"
+    tree = ast.parse(schema_path.read_text(encoding="utf-8"))
+    type_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == type_name
+    )
+    resolver = next(
+        node
+        for node in type_node.body
+        if isinstance(node, ast.FunctionDef) and node.name == resolver_name
+    )
+    loader_get = next(
+        node
+        for node in ast.walk(resolver)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+    )
+    return ast.literal_eval(loader_get.args[0])
+
+
+class MultilingualSearchNamesTest(unittest.TestCase):
+    def _run_loader(self, function_name, model_name, rows, ids):
+        db = FakeDB(rows)
+        model = TranslationModel
+        loader = load_function(
+            function_name,
+            {
+                "db": db,
+                model_name: model,
+                "defaultdict": defaultdict,
+                "Promise": ImmediatePromise,
+            },
+        )
+        result = loader(ids)
+        self.assertIs(db.session.queried_model, model)
+        self.assertEqual(db.session.query_object.filter_expression, ("in", tuple(ids)))
+        self.assertIsNotNone(db.session.query_object.order_fields)
+        return result
+
+    def test_item_names_include_every_translation_and_preserve_batch_order(self):
+        rows = [
+            Translation(item_id="item-b", locale="en", name="Bow"),
+            Translation(item_id="item-b", locale="fr", name="Arc"),
+            Translation(item_id="item-a", locale="en", name="Sword"),
+            Translation(item_id="item-a", locale="es", name="Espada"),
+        ]
+        self.assertEqual(
+            self._run_loader(
+                "load_all_item_names",
+                "ModelItemTranslation",
+                rows,
+                ["item-a", "missing", "item-b"],
+            ),
+            [["Sword", "Espada"], [], ["Bow", "Arc"]],
+        )
+
+    def test_set_names_include_every_translation_and_use_empty_list_fallback(self):
+        rows = [
+            Translation(set_id="set-2", locale="de", name="Zweites Set"),
+            Translation(set_id="set-2", locale="en", name="Second Set"),
+        ]
+        self.assertEqual(
+            self._run_loader(
+                "load_all_set_names",
+                "ModelSetTranslation",
+                rows,
+                ["set-1", "set-2", "set-3"],
+            ),
+            [[], ["Zweites Set", "Second Set"], []],
+        )
+
+    def test_search_name_resolvers_use_the_all_translation_loaders(self):
+        self.assertEqual(
+            resolver_loader_name("Item", "resolve_search_names"),
+            "all_item_names_loader",
+        )
+        self.assertEqual(
+            resolver_loader_name("Set", "resolve_search_names"),
+            "all_set_names_loader",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add batched loaders for all translated item and set names
- expose `searchNames` while preserving the request-locale `name` for display
- keep generated schema types aligned without adding search-only fields to shared UI fragments

## Validation
- `python -m unittest test_multilingual_search_names.py`
- full 19-test server catalog suite
- client TypeScript type-check

## Stack
Depends on #516. Review only the multilingual loader/schema commit in this PR.
