### PR TITLE
Cache the public app shell for offline use

### DIFF
--- a/client/common/registerServiceWorker.ts
+++ b/client/common/registerServiceWorker.ts
@@ -1,0 +1,55 @@
+const canUseServiceWorker = () =>
+  process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator;
+
+export const cachePublicRouteForOffline = async (navigationUrl: string) => {
+  if (!canUseServiceWorker()) return;
+
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    (navigator.serviceWorker.controller ?? registration.active)?.postMessage({
+      type: 'CACHE_APP_SHELL',
+      navigationUrl,
+      assetUrls: [],
+    });
+  } catch {
+    // Online navigation must not depend on service workers.
+  }
+};
+
+export default function registerServiceWorker() {
+  if (!canUseServiceWorker()) return;
+
+  const register = async () => {
+    try {
+      const registration = await navigator.serviceWorker.register(
+        '/service-worker.js',
+      );
+      await navigator.serviceWorker.ready;
+
+      const assetUrls = performance
+        .getEntriesByType('resource')
+        .map((entry) => entry.name)
+        .filter((url) => {
+          const parsedUrl = new URL(url);
+          return (
+            parsedUrl.origin === window.location.origin &&
+            parsedUrl.pathname.startsWith('/_next/static/')
+          );
+        });
+
+      (navigator.serviceWorker.controller ?? registration.active)?.postMessage({
+        type: 'CACHE_APP_SHELL',
+        navigationUrl: window.location.href,
+        assetUrls,
+      });
+    } catch {
+      // App startup and online behavior must not depend on service workers.
+    }
+  };
+
+  if (document.readyState === 'complete') {
+    void register();
+  } else {
+    window.addEventListener('load', register, { once: true });
+  }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "start": "next start",
     "type-check": "tsc",
     "test:catalog": "ts-node --project catalog/tsconfig.test.json catalog/catalogLink.test.ts",
+    "test:service-worker": "node service-worker.test.js",
     "test:suggestions": "ts-node --project catalog/tsconfig.test.json components/common/itemSuggestionUtils.test.ts",
     "generate": "graphql-codegen && npx prettier --write ./__generated__/globalTypes.ts && npx prettier --write ./graphql/**/__generated__/*.ts",
     "codegen": "yarn generate",

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -39,6 +39,9 @@ import StaticFunctions from 'components/common/StaticFunctions';
 import { createCache, StyleProvider } from '@ant-design/cssinjs';
 import type Entity from '@ant-design/cssinjs/es/Cache';
 import createEmotionCache from 'common/createEmotionCache';
+import registerServiceWorker, {
+  cachePublicRouteForOffline,
+} from 'common/registerServiceWorker';
 
 Router.events.on('routeChangeComplete', (url) => gtag.pageview(url));
 config.autoAddCss = false;
@@ -92,6 +95,14 @@ const DofusLabApp = ({
   useEffect(() => {
     dispatch({ type: AppliedBuffActionType.CLEAR_ALL });
   }, [customSetId]);
+
+  useEffect(() => {
+    registerServiceWorker();
+  }, []);
+
+  useEffect(() => {
+    void cachePublicRouteForOffline(window.location.href);
+  }, [router.asPath]);
 
   const [api, contextHolder] = notification.useNotification();
 

--- a/client/public/service-worker.js
+++ b/client/public/service-worker.js
@@ -1,0 +1,131 @@
+/* global self, caches, fetch */
+
+const CACHE_PREFIX = 'dofuslab-app-shell-';
+const CACHE_NAME = `${CACHE_PREFIX}v2`;
+
+const isSameOrigin = (url) => url.origin === self.location.origin;
+const isApiRequest = (url) => url.pathname.startsWith('/api/');
+const isNextStaticAsset = (url) =>
+  isSameOrigin(url) && url.pathname.startsWith('/_next/static/');
+const PUBLIC_LOCALES = new Set(['en', 'fr', 'it', 'es', 'pt']);
+const isPublicCatalogRoute = (url) => {
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (PUBLIC_LOCALES.has(segments[0])) segments.shift();
+
+  // Only the static selectors without a custom-set UUID are public documents.
+  return (
+    segments.length === 2 &&
+    segments[0] === 'equip' &&
+    (segments[1] === 'set' || /^[a-z]+(?:-\d+)?$/.test(segments[1]))
+  );
+};
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((names) =>
+        Promise.all(
+          names
+            .filter(
+              (name) => name.startsWith(CACHE_PREFIX) && name !== CACHE_NAME,
+            )
+            .map((name) => caches.delete(name)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+const cacheSuccessfulResponse = async (request, response) => {
+  if (response.ok && response.type !== 'opaque') {
+    const cache = await caches.open(CACHE_NAME);
+    await cache.put(request, response.clone());
+  }
+
+  return response;
+};
+
+const networkFirstNavigation = async (request) => {
+  try {
+    const response = await fetch(request);
+    return cacheSuccessfulResponse(request, response);
+  } catch (error) {
+    const cachedResponse = await caches.match(request);
+    if (cachedResponse) return cachedResponse;
+    throw error;
+  }
+};
+
+const cacheFirstStaticAsset = async (request) => {
+  const cachedResponse = await caches.match(request);
+  if (cachedResponse) return cachedResponse;
+
+  const response = await fetch(request);
+  return cacheSuccessfulResponse(request, response);
+};
+
+const cacheUrlIfMissing = async (cache, url) => {
+  if (await cache.match(url)) return;
+
+  const response = await fetch(url);
+  if (response.ok && response.type !== 'opaque') {
+    await cache.put(url, response);
+  }
+};
+
+self.addEventListener('message', (event) => {
+  if (event.data?.type !== 'CACHE_APP_SHELL') return;
+
+  let navigationUrl;
+  let assetUrls;
+  try {
+    navigationUrl = new URL(event.data.navigationUrl);
+    assetUrls = Array.isArray(event.data.assetUrls)
+      ? event.data.assetUrls.map((url) => new URL(url))
+      : [];
+  } catch {
+    return;
+  }
+  const urls = [];
+
+  if (
+    isSameOrigin(navigationUrl) &&
+    !isApiRequest(navigationUrl) &&
+    isPublicCatalogRoute(navigationUrl)
+  ) {
+    urls.push(navigationUrl.href);
+  }
+  urls.push(
+    ...assetUrls.filter(isNextStaticAsset).map((url) => url.href),
+  );
+
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) =>
+        Promise.all(urls.map((url) => cacheUrlIfMissing(cache, url))),
+      ),
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+  if (!isSameOrigin(url) || isApiRequest(url)) return;
+
+  if (request.mode === 'navigate' && isPublicCatalogRoute(url)) {
+    event.respondWith(networkFirstNavigation(request));
+    return;
+  }
+
+  if (isNextStaticAsset(url)) {
+    event.respondWith(cacheFirstStaticAsset(request));
+  }
+});

--- a/client/service-worker.test.js
+++ b/client/service-worker.test.js
@@ -1,0 +1,179 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const listeners = {};
+const storedResponses = new Map();
+let fetchCalls = 0;
+let fetchImplementation = async () => {
+  fetchCalls += 1;
+  return new Response('network response');
+};
+
+const requestKey = (request) =>
+  typeof request === 'string' ? request : request.url;
+const cache = {
+  match: async (request) => storedResponses.get(requestKey(request)),
+  put: async (request, response) => {
+    storedResponses.set(requestKey(request), response);
+  },
+};
+
+const context = {
+  URL,
+  Response,
+  caches: {
+    delete: async () => true,
+    keys: async () => [],
+    match: async (request) => storedResponses.get(requestKey(request)),
+    open: async () => cache,
+  },
+  fetch: (...args) => fetchImplementation(...args),
+  self: {
+    addEventListener: (name, listener) => {
+      listeners[name] = listener;
+    },
+    clients: { claim: async () => undefined },
+    location: { origin: 'https://dofuslab.test' },
+    skipWaiting: () => undefined,
+  },
+};
+
+vm.runInNewContext(
+  fs.readFileSync(path.join(__dirname, 'public/service-worker.js'), 'utf8'),
+  context,
+);
+
+const dispatchFetch = async (request) => {
+  let responsePromise;
+  listeners.fetch({
+    request,
+    respondWith: (promise) => {
+      responsePromise = promise;
+    },
+  });
+  return responsePromise;
+};
+
+const dispatchMessage = async (data) => {
+  let work;
+  listeners.message({
+    data,
+    waitUntil: (promise) => {
+      work = promise;
+    },
+  });
+  await work;
+};
+
+const request = (pathname, overrides = {}) => ({
+  method: 'GET',
+  mode: 'cors',
+  url: `https://dofuslab.test${pathname}`,
+  ...overrides,
+});
+
+(async () => {
+  assert.equal(
+    await dispatchFetch(request('/api/graphql', { method: 'POST' })),
+    undefined,
+    'GraphQL POST requests are not intercepted',
+  );
+  assert.equal(
+    await dispatchFetch(request('/api/graphql')),
+    undefined,
+    'API GET requests are not intercepted',
+  );
+  assert.equal(
+    await dispatchFetch(request('/images/item.png')),
+    undefined,
+    'unrelated runtime assets are not intercepted',
+  );
+
+  const privateRoutes = [
+    '/en/build/private-uuid/',
+    '/en/view/private-uuid/',
+    '/en/my-builds/',
+    '/en/user/someone/',
+    '/en/equip/hat/private-uuid/',
+    '/en/equip/set/private-uuid/',
+    '/en/equip/not_a_slot/',
+    '/en/reset-password/?token=secret',
+  ];
+  for (const pathname of privateRoutes) {
+    const privateNavigation = request(pathname, { mode: 'navigate' });
+    assert.equal(
+      await dispatchFetch(privateNavigation),
+      undefined,
+      `${pathname} document is not intercepted`,
+    );
+    await dispatchMessage({
+      type: 'CACHE_APP_SHELL',
+      navigationUrl: privateNavigation.url,
+      assetUrls: [],
+    });
+    assert.ok(
+      !storedResponses.has(privateNavigation.url),
+      `${pathname} document cannot be seeded into the cache`,
+    );
+  }
+
+  const navigation = request('/en/equip/hat/', { mode: 'navigate' });
+  const onlineResponse = await dispatchFetch(navigation);
+  assert.equal(await onlineResponse.text(), 'network response');
+  assert.equal(fetchCalls, 1, 'visited navigation is fetched from the network');
+  assert.ok(
+    storedResponses.has(navigation.url),
+    'successful navigation is cached for offline reload',
+  );
+
+  fetchImplementation = async () => {
+    fetchCalls += 1;
+    throw new Error('offline');
+  };
+  const offlineResponse = await dispatchFetch(navigation);
+  assert.equal(await offlineResponse.text(), 'network response');
+
+  const staticAsset = request('/_next/static/chunks/app-123.js');
+  storedResponses.set(staticAsset.url, new Response('cached asset'));
+  const callsBeforeStatic = fetchCalls;
+  const staticResponse = await dispatchFetch(staticAsset);
+  assert.equal(await staticResponse.text(), 'cached asset');
+  assert.equal(
+    fetchCalls,
+    callsBeforeStatic,
+    'Next static assets use the cache before the network',
+  );
+
+  fetchImplementation = async () => {
+    fetchCalls += 1;
+    return new Response('seeded');
+  };
+  await dispatchMessage({
+    type: 'CACHE_APP_SHELL',
+    navigationUrl: 'https://dofuslab.test/fr/equip/set/',
+    assetUrls: [
+      'https://dofuslab.test/_next/static/chunks/new-456.js',
+      'https://dofuslab.test/api/graphql',
+      'https://cdn.example.test/_next/static/chunks/external.js',
+    ],
+  });
+  assert.ok(storedResponses.has('https://dofuslab.test/fr/equip/set/'));
+  assert.ok(
+    storedResponses.has(
+      'https://dofuslab.test/_next/static/chunks/new-456.js',
+    ),
+  );
+  assert.ok(!storedResponses.has('https://dofuslab.test/api/graphql'));
+  assert.ok(
+    !storedResponses.has(
+      'https://cdn.example.test/_next/static/chunks/external.js',
+    ),
+  );
+
+  console.log('service-worker tests passed');
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- register a production service worker from the app shell
- cache safe public selector HTML and Next static assets for offline startup
- avoid caching private build HTML or GraphQL responses
- version and clean old app-shell caches during activation

## Validation
- `yarn type-check`
- `yarn test:service-worker`
- full client test matrix on the complete stack

## Scope note
Catalog data remains owned by IndexedDB in #519. This service worker handles the public app shell and static assets; item images continue to use ordinary HTTP caching.

## Stack
Depends on #519.
