### PR TITLE
Fix Next.js hydration and initial styling

### DIFF
--- a/client/common/createEmotionCache.ts
+++ b/client/common/createEmotionCache.ts
@@ -1,0 +1,9 @@
+import createCache from '@emotion/cache';
+
+const createEmotionCache = () =>
+  createCache({
+    key: 'css',
+    prepend: true,
+  });
+
+export default createEmotionCache;

--- a/client/components/desktop/Layout.tsx
+++ b/client/components/desktop/Layout.tsx
@@ -261,329 +261,325 @@ function Layout({ children, showSwitch }: LayoutProps) {
   );
 
   return (
-    <>
-      <AntdLayout
-        css={{
-          height: '100vh',
-          backgroundColor: theme.body?.background,
-        }}
-        suppressHydrationWarning
-      >
-        <Global
-          styles={{
-            html: {
-              fontSize: 18,
+    <AntdLayout
+      css={{
+        height: '100vh',
+        backgroundColor: theme.body?.background,
+      }}
+      suppressHydrationWarning
+    >
+      <Global
+        styles={{
+          html: {
+            fontSize: 18,
+          },
+          body: {
+            backgroundColor: theme.body?.background,
+            [mq[1]]: {
+              height: '100vh',
             },
-            body: {
-              backgroundColor: theme.body?.background,
-              [mq[1]]: {
-                height: '100vh',
-              },
-              fontSize: '0.8rem',
-              msScrollbarFaceColor: theme.scrollbar?.background,
-              msScrollbarBaseColor: theme.scrollbar?.background,
-              msScrollbar3dlightColor: theme.scrollbar?.background,
-              msScrollbarHighlightColor: theme.scrollbar?.background,
-              msScrollbarTrackColor: theme.scrollbar?.trackBackground,
-              msScrollbarArrowColor: theme.scrollbar?.trackBackground,
-              msScrollbarShadowColor: theme.scrollbar?.background,
-              msScrollbarDarkshadowColor: theme.scrollbar?.background,
-            },
-            '#__next': {
-              height: '100%',
-            },
-            '&::-webkit-scrollbar': {
-              width: 12,
-              height: 3,
-
-              '&-button': {
-                backgroundColor: theme.scrollbar?.background,
-                '&:decrement': {
-                  borderBottom: `1px solid ${theme.scrollbar?.buttonBorder}`,
-                },
-                '&:increment': {
-                  borderTop: `1px solid ${theme.scrollbar?.buttonBorder}`,
-                },
-              },
-
-              '&-track': {
-                backgroundColor: theme.scrollbar?.background,
-                '&-piece': {
-                  backgroundColor: theme.scrollbar?.trackBackground,
-                },
-              },
-
-              '&-thumb': {
-                height: 20,
-                backgroundColor: theme.scrollbar?.background,
-              },
-
-              '&-corner': {
-                backgroundColor: theme.scrollbar?.background,
-              },
-            },
-          }}
-        />
-        <StatusChecker />
-        <AntdLayout.Header
-          css={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            background: theme.header?.background,
-            borderBottom: `1px solid ${theme.border?.default}`,
-            padding: '0 20px',
             fontSize: '0.8rem',
-          }}
-        >
-          <div css={{ display: 'flex', alignItems: 'center' }}>
-            <Link href="/" as="/">
-              <div
-                css={{
-                  fontWeight: 500,
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                }}
-              >
-                <img
-                  src={getImageUrl(
-                    theme.name === LIGHT_THEME_NAME
-                      ? 'logo/DL-Full_Light.svg'
-                      : 'logo/DL-Full_Dark.svg',
-                  )}
-                  width={120}
-                  height={36}
-                  css={{ width: 120 }}
-                  alt="DofusLab"
-                />
-              </div>
-            </Link>
-          </div>
-          <div css={{ display: 'flex', alignItems: 'center' }}>
-            {showSwitch && classicSwitch}
-            {data?.currentUser ? (
-              <div>
-                {langSelect}
-                {data.currentUser.verified && (
-                  <>
-                    <Button onClick={openDrawer} css={{ marginLeft: 12 }}>
-                      {t('MY_BUILDS', { ns: 'common' })}
-                    </Button>
-                    <Drawer
-                      open={drawerVisible}
-                      closable
-                      onClose={closeDrawer}
-                      width="min(100%, 1000px)"
-                      forceRender
-                    >
-                      {isReady && (
-                        <BuildList
-                          onClose={closeDrawer}
-                          username={data.currentUser.username}
-                          isEditable
-                          getScrollParent={() => {
-                            return drawerBody.current;
-                          }}
-                          isMobile={false}
-                        />
-                      )}
-                    </Drawer>
-                    <Dropdown
-                      overlay={
-                        <Menu>
-                          <Menu.ItemGroup
-                            title={
-                              <span>
-                                {t('WELCOME')}{' '}
-                                <Link
-                                  href={`/user/${data.currentUser.username}`}
-                                >
-                                  {data.currentUser.username}
-                                </Link>
-                              </span>
-                            }
-                          >
-                            <Menu.Item
-                              key="change-password"
-                              onClick={openPasswordModal}
-                            >
-                              <FontAwesomeIcon
-                                icon={faKey}
-                                css={{ marginRight: 8 }}
-                              />
-                              {t('CHANGE_PASSWORD')}
-                            </Menu.Item>
-                            <Menu.Item
-                              key="build-settings"
-                              onClick={openBuildSettings}
-                            >
-                              <FontAwesomeIcon
-                                icon={faWrench}
-                                css={{ marginRight: 8 }}
-                              />
-                              {t('DEFAULT_BUILD_SETTINGS', { ns: 'common' })}
-                            </Menu.Item>
-                            <Menu.Item
-                              key="keyboard-shortcuts"
-                              onClick={openKeyboardShortcuts}
-                            >
-                              <FontAwesomeIcon
-                                icon={faKeyboard}
-                                css={{ marginRight: 8 }}
-                              />
-                              {t('KEYBOARD_SHORTCUTS', {
-                                ns: 'keyboard_shortcut',
-                              })}
-                            </Menu.Item>
-                          </Menu.ItemGroup>
-                        </Menu>
-                      }
-                    >
-                      <span>
-                        <Button css={{ marginLeft: 12 }}>
-                          {t('MENU', { ns: 'common' })}{' '}
-                          <DownOutlined css={{ fontSize: '12px' }} />
-                        </Button>
-                      </span>
-                    </Dropdown>
-                  </>
-                )}
-                <Button
-                  key="logout"
-                  onClick={logoutHandler}
-                  css={{ marginLeft: 12 }}
-                >
-                  {t('LOGOUT')}
-                </Button>
-              </div>
-            ) : (
-              <div css={{ display: 'flex', alignItems: 'center' }}>
-                <Button onClick={openKeyboardShortcuts}>
-                  {t('SHORTCUTS', { ns: 'keyboard_shortcut' })}
-                </Button>
-                {langSelect}
-                <Button
-                  onClick={openLoginModal}
-                  type="link"
-                  css={{
-                    padding: 0,
-                    color: theme.text?.link?.default,
-                    marginLeft: 16,
-                  }}
-                >
-                  {t('LOGIN')}
-                </Button>
-                <span
-                  css={{
-                    margin: '-2px 12px 0',
-                  }}
-                >
-                  {t('OR', { ns: 'common' })}
-                </span>
-                <Button onClick={openSignUpModal} type="default">
-                  {t('SIGN_UP')}
-                </Button>
-              </div>
-            )}
-            <Divider type="vertical" css={{ margin: '0 8px 0 12px' }} />
+            msScrollbarFaceColor: theme.scrollbar?.background,
+            msScrollbarBaseColor: theme.scrollbar?.background,
+            msScrollbar3dlightColor: theme.scrollbar?.background,
+            msScrollbarHighlightColor: theme.scrollbar?.background,
+            msScrollbarTrackColor: theme.scrollbar?.trackBackground,
+            msScrollbarArrowColor: theme.scrollbar?.trackBackground,
+            msScrollbarShadowColor: theme.scrollbar?.background,
+            msScrollbarDarkshadowColor: theme.scrollbar?.background,
+          },
+          '#__next': {
+            height: '100%',
+          },
+          '&::-webkit-scrollbar': {
+            width: 12,
+            height: 3,
+
+            '&-button': {
+              backgroundColor: theme.scrollbar?.background,
+              '&:decrement': {
+                borderBottom: `1px solid ${theme.scrollbar?.buttonBorder}`,
+              },
+              '&:increment': {
+                borderTop: `1px solid ${theme.scrollbar?.buttonBorder}`,
+              },
+            },
+
+            '&-track': {
+              backgroundColor: theme.scrollbar?.background,
+              '&-piece': {
+                backgroundColor: theme.scrollbar?.trackBackground,
+              },
+            },
+
+            '&-thumb': {
+              height: 20,
+              backgroundColor: theme.scrollbar?.background,
+            },
+
+            '&-corner': {
+              backgroundColor: theme.scrollbar?.background,
+            },
+          },
+        }}
+      />
+      <StatusChecker />
+      <AntdLayout.Header
+        css={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          background: theme.header?.background,
+          borderBottom: `1px solid ${theme.border?.default}`,
+          padding: '0 20px',
+          fontSize: '0.8rem',
+        }}
+      >
+        <div css={{ display: 'flex', alignItems: 'center' }}>
+          <Link href="/" as="/">
             <div
               css={{
-                marginLeft: 4,
+                fontWeight: 500,
+                cursor: 'pointer',
                 display: 'flex',
                 alignItems: 'center',
-                '> *': {
-                  fontSize: '1.2rem',
-                  '&:not(:last-of-type)': {
-                    marginRight: 12,
-                  },
-                },
               }}
             >
-              <a
-                href={DISCORD_SERVER_LINK}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Tooltip
-                  placement="bottomLeft"
-                  title={t('JOIN_US_DISCORD', { ns: 'common' })}
-                >
-                  <FontAwesomeIcon icon={faDiscord} />
-                </Tooltip>
-              </a>
-              <a
-                href={GITHUB_REPO_LINK}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Tooltip
-                  placement="bottomLeft"
-                  title={t('CONTRIBUTE_GITHUB', { ns: 'common' })}
-                >
-                  <FontAwesomeIcon icon={faGithub} />
-                </Tooltip>
-              </a>
-              <a
-                href={BUY_ME_COFFEE_LINK}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Tooltip
-                  placement="bottomLeft"
-                  title={t('BUY_US_COFFEE', { ns: 'common' })}
-                >
-                  <FontAwesomeIcon icon={faMugHot} />
-                </Tooltip>
-              </a>
+              <img
+                src={getImageUrl(
+                  theme.name === LIGHT_THEME_NAME
+                    ? 'logo/DL-Full_Light.svg'
+                    : 'logo/DL-Full_Dark.svg',
+                )}
+                width={120}
+                height={36}
+                css={{ width: 120 }}
+                alt="DofusLab"
+              />
             </div>
+          </Link>
+        </div>
+        <div css={{ display: 'flex', alignItems: 'center' }}>
+          {showSwitch && classicSwitch}
+          {data?.currentUser ? (
+            <div>
+              {langSelect}
+              {data.currentUser.verified && (
+                <>
+                  <Button onClick={openDrawer} css={{ marginLeft: 12 }}>
+                    {t('MY_BUILDS', { ns: 'common' })}
+                  </Button>
+                  <Drawer
+                    open={drawerVisible}
+                    closable
+                    onClose={closeDrawer}
+                    width="min(100%, 1000px)"
+                    forceRender
+                  >
+                    {isReady && (
+                      <BuildList
+                        onClose={closeDrawer}
+                        username={data.currentUser.username}
+                        isEditable
+                        getScrollParent={() => {
+                          return drawerBody.current;
+                        }}
+                        isMobile={false}
+                      />
+                    )}
+                  </Drawer>
+                  <Dropdown
+                    overlay={
+                      <Menu>
+                        <Menu.ItemGroup
+                          title={
+                            <span>
+                              {t('WELCOME')}{' '}
+                              <Link href={`/user/${data.currentUser.username}`}>
+                                {data.currentUser.username}
+                              </Link>
+                            </span>
+                          }
+                        >
+                          <Menu.Item
+                            key="change-password"
+                            onClick={openPasswordModal}
+                          >
+                            <FontAwesomeIcon
+                              icon={faKey}
+                              css={{ marginRight: 8 }}
+                            />
+                            {t('CHANGE_PASSWORD')}
+                          </Menu.Item>
+                          <Menu.Item
+                            key="build-settings"
+                            onClick={openBuildSettings}
+                          >
+                            <FontAwesomeIcon
+                              icon={faWrench}
+                              css={{ marginRight: 8 }}
+                            />
+                            {t('DEFAULT_BUILD_SETTINGS', { ns: 'common' })}
+                          </Menu.Item>
+                          <Menu.Item
+                            key="keyboard-shortcuts"
+                            onClick={openKeyboardShortcuts}
+                          >
+                            <FontAwesomeIcon
+                              icon={faKeyboard}
+                              css={{ marginRight: 8 }}
+                            />
+                            {t('KEYBOARD_SHORTCUTS', {
+                              ns: 'keyboard_shortcut',
+                            })}
+                          </Menu.Item>
+                        </Menu.ItemGroup>
+                      </Menu>
+                    }
+                  >
+                    <span>
+                      <Button css={{ marginLeft: 12 }}>
+                        {t('MENU', { ns: 'common' })}{' '}
+                        <DownOutlined css={{ fontSize: '12px' }} />
+                      </Button>
+                    </span>
+                  </Dropdown>
+                </>
+              )}
+              <Button
+                key="logout"
+                onClick={logoutHandler}
+                css={{ marginLeft: 12 }}
+              >
+                {t('LOGOUT')}
+              </Button>
+            </div>
+          ) : (
+            <div css={{ display: 'flex', alignItems: 'center' }}>
+              <Button onClick={openKeyboardShortcuts}>
+                {t('SHORTCUTS', { ns: 'keyboard_shortcut' })}
+              </Button>
+              {langSelect}
+              <Button
+                onClick={openLoginModal}
+                type="link"
+                css={{
+                  padding: 0,
+                  color: theme.text?.link?.default,
+                  marginLeft: 16,
+                }}
+              >
+                {t('LOGIN')}
+              </Button>
+              <span
+                css={{
+                  margin: '-2px 12px 0',
+                }}
+              >
+                {t('OR', { ns: 'common' })}
+              </span>
+              <Button onClick={openSignUpModal} type="default">
+                {t('SIGN_UP')}
+              </Button>
+            </div>
+          )}
+          <Divider type="vertical" css={{ margin: '0 8px 0 12px' }} />
+          <div
+            css={{
+              marginLeft: 4,
+              display: 'flex',
+              alignItems: 'center',
+              '> *': {
+                fontSize: '1.2rem',
+                '&:not(:last-of-type)': {
+                  marginRight: 12,
+                },
+              },
+            }}
+          >
+            <a
+              href={DISCORD_SERVER_LINK}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Tooltip
+                placement="bottomLeft"
+                title={t('JOIN_US_DISCORD', { ns: 'common' })}
+              >
+                <FontAwesomeIcon icon={faDiscord} />
+              </Tooltip>
+            </a>
+            <a
+              href={GITHUB_REPO_LINK}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Tooltip
+                placement="bottomLeft"
+                title={t('CONTRIBUTE_GITHUB', { ns: 'common' })}
+              >
+                <FontAwesomeIcon icon={faGithub} />
+              </Tooltip>
+            </a>
+            <a
+              href={BUY_ME_COFFEE_LINK}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Tooltip
+                placement="bottomLeft"
+                title={t('BUY_US_COFFEE', { ns: 'common' })}
+              >
+                <FontAwesomeIcon icon={faMugHot} />
+              </Tooltip>
+            </a>
           </div>
-        </AntdLayout.Header>
-        <AntdLayout.Content
-          css={{
-            marginTop: 12,
-            display: 'flex',
-            flexDirection: 'column',
-            padding: 0,
-            flex: 1,
-            minHeight: 0,
-          }}
-        >
-          {children}
-        </AntdLayout.Content>
-        {showLoginModal && (
-          <LoginModal
-            open={showLoginModal}
-            onClose={closeLoginModal}
-            openSignUpModal={openSignUpModal}
-          />
-        )}
-        {showSignUpModal && (
-          <SignUpModal
-            open={showSignUpModal}
-            onClose={closeSignUpModal}
-            openLoginModal={openLoginModal}
-          />
-        )}
-        {showPasswordModal && (
-          <ChangePasswordModal
-            open={showPasswordModal}
-            onClose={closePasswordModal}
-          />
-        )}
-        {showBuildSettings && (
-          <DefaultBuildSettingsModal
-            open={showBuildSettings}
-            onClose={closeBuildSettings}
-          />
-        )}
-        {showKeyboardShortcuts && (
-          <KeyboardShortcutsModal
-            open={showKeyboardShortcuts}
-            onClose={closeKeyboardShortcuts}
-          />
-        )}
-      </AntdLayout>
-    </>
+        </div>
+      </AntdLayout.Header>
+      <AntdLayout.Content
+        css={{
+          marginTop: 12,
+          display: 'flex',
+          flexDirection: 'column',
+          padding: 0,
+          flex: 1,
+          minHeight: 0,
+        }}
+      >
+        {children}
+      </AntdLayout.Content>
+      {showLoginModal && (
+        <LoginModal
+          open={showLoginModal}
+          onClose={closeLoginModal}
+          openSignUpModal={openSignUpModal}
+        />
+      )}
+      {showSignUpModal && (
+        <SignUpModal
+          open={showSignUpModal}
+          onClose={closeSignUpModal}
+          openLoginModal={openLoginModal}
+        />
+      )}
+      {showPasswordModal && (
+        <ChangePasswordModal
+          open={showPasswordModal}
+          onClose={closePasswordModal}
+        />
+      )}
+      {showBuildSettings && (
+        <DefaultBuildSettingsModal
+          open={showBuildSettings}
+          onClose={closeBuildSettings}
+        />
+      )}
+      {showKeyboardShortcuts && (
+        <KeyboardShortcutsModal
+          open={showKeyboardShortcuts}
+          onClose={closeKeyboardShortcuts}
+        />
+      )}
+    </AntdLayout>
   );
 }
 

--- a/client/components/desktop/Layout.tsx
+++ b/client/components/desktop/Layout.tsx
@@ -17,7 +17,6 @@ import {
   Switch,
 } from 'antd';
 import { useRouter } from 'next/router';
-import { AntdRegistry } from '@ant-design/nextjs-registry';
 
 import { useQuery, useMutation, useApolloClient } from '@apollo/client';
 import { currentUser as CurrentUserQueryType } from 'graphql/queries/__generated__/currentUser';
@@ -262,7 +261,7 @@ function Layout({ children, showSwitch }: LayoutProps) {
   );
 
   return (
-    <AntdRegistry>
+    <>
       <AntdLayout
         css={{
           height: '100vh',
@@ -584,7 +583,7 @@ function Layout({ children, showSwitch }: LayoutProps) {
           />
         )}
       </AntdLayout>
-    </AntdRegistry>
+    </>
   );
 }
 

--- a/client/components/mobile/Layout.tsx
+++ b/client/components/mobile/Layout.tsx
@@ -370,147 +370,139 @@ function Layout({ children }: LayoutProps) {
   const theme = useTheme();
 
   return (
-    <>
-      <AntdLayout
-        css={{ height: '100%', minHeight: '100vh' }}
-        suppressHydrationWarning
+    <AntdLayout
+      css={{ height: '100%', minHeight: '100vh' }}
+      suppressHydrationWarning
+    >
+      <Global
+        styles={{
+          html: {
+            fontSize: 18,
+          },
+          body: {
+            height: 'auto',
+          },
+        }}
+      />
+      <StatusChecker />
+      <AntdLayout.Header
+        css={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          background: theme.header?.background,
+          borderBottom: `1px solid ${theme.border?.default}`,
+          padding: '0 12px',
+          fontSize: '0.8rem',
+        }}
       >
-        <Global
-          styles={{
-            html: {
-              fontSize: 18,
-            },
-            body: {
-              height: 'auto',
-            },
-          }}
-        />
-        <StatusChecker />
-        <AntdLayout.Header
+        <Link href="/" as="/">
+          <div css={{ fontWeight: 500, display: 'flex', alignItems: 'center' }}>
+            <img
+              src={getImageUrl(
+                theme.name === LIGHT_THEME_NAME
+                  ? 'logo/DL-Full_Light.svg'
+                  : 'logo/DL-Full_Dark.svg',
+              )}
+              width={120}
+              height={36}
+              css={{ width: 120 }}
+              alt="DofusLab"
+            />
+          </div>
+        </Link>
+        <Button onClick={openDrawer} size="large" css={{ fontSize: '0.9rem' }}>
+          <MenuOutlined />
+        </Button>
+        <Drawer
+          open={showDrawer}
+          closable
+          onClose={closeDrawer}
           css={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            background: theme.header?.background,
-            borderBottom: `1px solid ${theme.border?.default}`,
-            padding: '0 12px',
-            fontSize: '0.8rem',
+            '.ant-drawer-body': {
+              padding: '44px 0 24px 0',
+            },
           }}
         >
-          <Link href="/" as="/">
+          {data?.currentUser && (
             <div
-              css={{ fontWeight: 500, display: 'flex', alignItems: 'center' }}
+              css={{
+                height: 40,
+                lineHeight: '40px',
+                paddingLeft: 24,
+                fontWeight: 500,
+              }}
             >
-              <img
-                src={getImageUrl(
-                  theme.name === LIGHT_THEME_NAME
-                    ? 'logo/DL-Full_Light.svg'
-                    : 'logo/DL-Full_Dark.svg',
-                )}
-                width={120}
-                height={36}
-                css={{ width: 120 }}
-                alt="DofusLab"
-              />
+              {t('WELCOME')}
+              <Link href={`/user/${data.currentUser.username}`}>
+                {data.currentUser.username}
+              </Link>
             </div>
-          </Link>
-          <Button
-            onClick={openDrawer}
-            size="large"
-            css={{ fontSize: '0.9rem' }}
-          >
-            <MenuOutlined />
-          </Button>
-          <Drawer
-            open={showDrawer}
-            closable
-            onClose={closeDrawer}
+          )}
+          <Menu
+            mode="inline"
+            onClick={menuClickHandler}
+            items={menuItems}
             css={{
-              '.ant-drawer-body': {
-                padding: '44px 0 24px 0',
+              border: 'none',
+              '.ant-menu-item, .ant-menu-submenu-title, .ant-menu-item:not(:last-child)':
+                {
+                  width: '100%',
+                  fontSize: '0.8rem',
+                  margin: 0,
+                },
+              '.ant-menu-item::after': {
+                left: 0,
+                right: 'auto',
+              },
+              '.ant-menu-item-divider': {
+                margin: '4px 0',
               },
             }}
-          >
-            {data?.currentUser && (
-              <div
-                css={{
-                  height: 40,
-                  lineHeight: '40px',
-                  paddingLeft: 24,
-                  fontWeight: 500,
-                }}
-              >
-                {t('WELCOME')}
-                <Link href={`/user/${data.currentUser.username}`}>
-                  {data.currentUser.username}
-                </Link>
-              </div>
-            )}
-            <Menu
-              mode="inline"
-              onClick={menuClickHandler}
-              items={menuItems}
-              css={{
-                border: 'none',
-                '.ant-menu-item, .ant-menu-submenu-title, .ant-menu-item:not(:last-child)':
-                  {
-                    width: '100%',
-                    fontSize: '0.8rem',
-                    margin: 0,
-                  },
-                '.ant-menu-item::after': {
-                  left: 0,
-                  right: 'auto',
-                },
-                '.ant-menu-item-divider': {
-                  margin: '4px 0',
-                },
-              }}
-              triggerSubMenuAction="click"
-            />
-          </Drawer>
-        </AntdLayout.Header>
-        <AntdLayout.Content
-          css={{
-            paddingTop: 12,
-            display: 'flex',
-            flexDirection: 'column',
-            paddingLeft: 8,
-            paddingRight: 8,
-            overflowAnchor: 'none',
-            position: 'relative',
-          }}
-        >
-          {children}
-        </AntdLayout.Content>
-        {showLoginModal && (
-          <LoginModal
-            open={showLoginModal}
-            onClose={closeLoginModal}
-            openSignUpModal={openSignUpModal}
+            triggerSubMenuAction="click"
           />
-        )}
-        {showSignUpModal && (
-          <SignUpModal
-            open={showSignUpModal}
-            onClose={closeSignUpModal}
-            openLoginModal={openLoginModal}
-          />
-        )}
-        {showPasswordModal && (
-          <ChangePasswordModal
-            open={showPasswordModal}
-            onClose={closePasswordModal}
-          />
-        )}
-        {showBuildSettings && (
-          <DefaultBuildSettingsModal
-            open={showBuildSettings}
-            onClose={closeBuildSettings}
-          />
-        )}
-      </AntdLayout>
-    </>
+        </Drawer>
+      </AntdLayout.Header>
+      <AntdLayout.Content
+        css={{
+          paddingTop: 12,
+          display: 'flex',
+          flexDirection: 'column',
+          paddingLeft: 8,
+          paddingRight: 8,
+          overflowAnchor: 'none',
+          position: 'relative',
+        }}
+      >
+        {children}
+      </AntdLayout.Content>
+      {showLoginModal && (
+        <LoginModal
+          open={showLoginModal}
+          onClose={closeLoginModal}
+          openSignUpModal={openSignUpModal}
+        />
+      )}
+      {showSignUpModal && (
+        <SignUpModal
+          open={showSignUpModal}
+          onClose={closeSignUpModal}
+          openLoginModal={openLoginModal}
+        />
+      )}
+      {showPasswordModal && (
+        <ChangePasswordModal
+          open={showPasswordModal}
+          onClose={closePasswordModal}
+        />
+      )}
+      {showBuildSettings && (
+        <DefaultBuildSettingsModal
+          open={showBuildSettings}
+          onClose={closeBuildSettings}
+        />
+      )}
+    </AntdLayout>
   );
 }
 

--- a/client/components/mobile/Layout.tsx
+++ b/client/components/mobile/Layout.tsx
@@ -12,7 +12,6 @@ import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import Cookies from 'js-cookie';
 import { LANGUAGES, langToFullName } from 'common/i18n-utils';
-import { AntdRegistry } from '@ant-design/nextjs-registry';
 
 import { useQuery, useMutation, useApolloClient } from '@apollo/client';
 import { currentUser as ICurrentUser } from 'graphql/queries/__generated__/currentUser';
@@ -371,7 +370,7 @@ function Layout({ children }: LayoutProps) {
   const theme = useTheme();
 
   return (
-    <AntdRegistry>
+    <>
       <AntdLayout
         css={{ height: '100%', minHeight: '100vh' }}
         suppressHydrationWarning
@@ -511,7 +510,7 @@ function Layout({ children }: LayoutProps) {
           />
         )}
       </AntdLayout>
-    </AntdRegistry>
+    </>
   );
 }
 

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "dev-turbopack": "NODE_OPTIONS='--inspect' && yarn && yarn codegen && next dev --turbopack",
     "dev-webpack": "NODE_OPTIONS='--inspect' && yarn && yarn codegen && next dev",
     "dev-docker": "NODE_OPTIONS='--inspect=0.0.0.0:9229' yarn codegen && next dev",
+    "postinstall": "patch-package",
     "build": "next build && tsc --project tsconfig.server.json",
     "start": "next start",
     "type-check": "tsc",
@@ -31,7 +32,9 @@
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@apollo/client": "3.2",
     "@artsy/fresnel": "^8.1.0",
+    "@emotion/cache": "11.14.0",
     "@emotion/react": "^11.7.1",
+    "@emotion/server": "11.11.0",
     "@fortawesome/fontawesome-svg-core": "^7.0.0",
     "@fortawesome/free-brands-svg-icons": "^7.0.0",
     "@fortawesome/free-regular-svg-icons": "^7.0.0",
@@ -85,6 +88,7 @@
     "graphql-codegen-apollo-next-ssr": "^1.7.4",
     "i18next-scanner": "^2.11.0",
     "nodemon": "^2.0.4",
+    "patch-package": "8.0.0",
     "sort-keys": "^4.0.0",
     "ts-node": "^8.10.2",
     "typescript": "^5.9.2"
@@ -101,6 +105,9 @@
   },
   "resolutions": {
     "@babel/runtime": "^7.24.6",
-    "@types/react": "19.1.12"
+    "@types/react": "19.1.12",
+    "rc-motion": "2.9.5",
+    "rc-resize-observer": "1.4.3",
+    "rc-util": "5.44.4"
   }
 }

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -10,7 +10,7 @@ import withApollo from 'common/apollo';
 import { config } from '@fortawesome/fontawesome-svg-core';
 import { MediaContextProvider } from 'components/common/Media';
 import Router, { useRouter } from 'next/router';
-import { ThemeProvider } from '@emotion/react';
+import { CacheProvider, EmotionCache, ThemeProvider } from '@emotion/react';
 
 import CustomSetQuery from 'graphql/queries/customSet.graphql';
 import {
@@ -36,17 +36,28 @@ import Head from 'next/head';
 import { App, ConfigProvider, notification, theme } from 'antd';
 import NotificationContext from 'common/notificationContext';
 import StaticFunctions from 'components/common/StaticFunctions';
-import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs';
+import { createCache, StyleProvider } from '@ant-design/cssinjs';
 import type Entity from '@ant-design/cssinjs/es/Cache';
+import createEmotionCache from 'common/createEmotionCache';
 
 Router.events.on('routeChangeComplete', (url) => gtag.pageview(url));
 config.autoAddCss = false;
 
 interface Props extends AppProps {
   apolloClient: ApolloClient<NormalizedCacheObject>;
+  emotionCache?: EmotionCache;
+  antDesignCache?: Entity;
 }
 
-const DofusLabApp = ({ Component, apolloClient, pageProps }: Props) => {
+const clientSideEmotionCache = createEmotionCache();
+
+const DofusLabApp = ({
+  Component,
+  apolloClient,
+  pageProps,
+  emotionCache = clientSideEmotionCache,
+  antDesignCache: providedAntDesignCache,
+}: Props) => {
   const router = useRouter();
   const { customSetId } = router.query;
 
@@ -107,44 +118,47 @@ const DofusLabApp = ({ Component, apolloClient, pageProps }: Props) => {
     ],
   );
 
-  // SSR Render
-  const cache = React.useMemo<Entity>(() => createCache(), []);
-  const styleText = extractStyle(cache);
+  const clientSideAntDesignCache = React.useMemo<Entity>(
+    () => createCache(),
+    [],
+  );
+  const antDesignCache = providedAntDesignCache || clientSideAntDesignCache;
 
   /* eslint-disable react/jsx-props-no-spreading */
   return (
-    <ApolloProvider client={apolloClient}>
-      <MediaContextProvider>
-        <ThemeProvider theme={darkTheme}>
-          <StyleProvider cache={cache}>
-            <ConfigProvider
-              theme={{
-                algorithm: theme.darkAlgorithm,
-              }}
-            >
-              <App>
-                <CustomSetContext.Provider value={customSetContextValue}>
-                  <NotificationContext.Provider
-                    value={notificationContextValue}
-                  >
-                    <Head>
-                      <meta
-                        name="viewport"
-                        content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-                      />
-                      {styleText}
-                    </Head>
-                    {contextHolder}
-                    <StaticFunctions />
-                    <Component {...pageProps} />
-                  </NotificationContext.Provider>
-                </CustomSetContext.Provider>
-              </App>
-            </ConfigProvider>
-          </StyleProvider>
-        </ThemeProvider>
-      </MediaContextProvider>
-    </ApolloProvider>
+    <CacheProvider value={emotionCache}>
+      <ApolloProvider client={apolloClient}>
+        <MediaContextProvider>
+          <ThemeProvider theme={darkTheme}>
+            <StyleProvider cache={antDesignCache} layer>
+              <ConfigProvider
+                theme={{
+                  algorithm: theme.darkAlgorithm,
+                }}
+              >
+                <App>
+                  <CustomSetContext.Provider value={customSetContextValue}>
+                    <NotificationContext.Provider
+                      value={notificationContextValue}
+                    >
+                      <Head>
+                        <meta
+                          name="viewport"
+                          content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+                        />
+                      </Head>
+                      {contextHolder}
+                      <StaticFunctions />
+                      <Component {...pageProps} />
+                    </NotificationContext.Provider>
+                  </CustomSetContext.Provider>
+                </App>
+              </ConfigProvider>
+            </StyleProvider>
+          </ThemeProvider>
+        </MediaContextProvider>
+      </ApolloProvider>
+    </CacheProvider>
   );
 };
 

--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -6,10 +6,12 @@ import Document, {
   DocumentProps,
   DocumentContext,
 } from 'next/document';
-import { extractStyle, createCache, StyleProvider } from '@ant-design/cssinjs';
+import { extractStyle, createCache } from '@ant-design/cssinjs';
+import createEmotionServer from '@emotion/server/create-instance';
 
 import { GA_TRACKING_ID } from '../gtag';
 import { mediaStyles } from '../components/common/Media';
+import createEmotionCache from '../common/createEmotionCache';
 
 const DofusLabDocument = ({ __NEXT_DATA__ }: DocumentProps) => {
   return (
@@ -77,27 +79,42 @@ const DofusLabDocument = ({ __NEXT_DATA__ }: DocumentProps) => {
 };
 
 DofusLabDocument.getInitialProps = async (ctx: DocumentContext) => {
-  const cache = createCache();
+  const antDesignCache = createCache();
+  const emotionCache = createEmotionCache();
+  const { extractCriticalToChunks } = createEmotionServer(emotionCache);
   const originalRenderPage = ctx.renderPage;
   ctx.renderPage = () =>
     originalRenderPage({
-      enhanceApp: (App) => (props) => (
-        <StyleProvider cache={cache}>
-          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-          <App {...props} />
-        </StyleProvider>
-      ),
+      enhanceApp: (App) => (props) => {
+        const appProps = { ...props, emotionCache, antDesignCache };
+
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        return <App {...appProps} />;
+      },
     });
 
   const initialProps = await Document.getInitialProps(ctx);
-  const style = extractStyle(cache, true);
+  const antDesignStyle = extractStyle(antDesignCache, true);
+  const emotionStyleChunks = extractCriticalToChunks(initialProps.html);
   return {
     ...initialProps,
     styles: (
       <>
         {initialProps.styles}
-        {/* eslint-disable-next-line react/no-danger */}
-        <style dangerouslySetInnerHTML={{ __html: style }} />
+        <style
+          data-rc-order="prepend"
+          data-rc-priority="-1000"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: antDesignStyle }}
+        />
+        {emotionStyleChunks.styles.map((style) => (
+          <style
+            data-emotion={`${style.key} ${style.ids.join(' ')}`}
+            key={style.key}
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: style.css }}
+          />
+        ))}
       </>
     ),
   };

--- a/client/patches/@artsy+fresnel+8.1.0.patch
+++ b/client/patches/@artsy+fresnel+8.1.0.patch
@@ -1,0 +1,70 @@
+diff --git a/node_modules/@artsy/fresnel/dist/Media.js b/node_modules/@artsy/fresnel/dist/Media.js
+index d785b8c..18fdd1e 100644
+--- a/node_modules/@artsy/fresnel/dist/Media.js
++++ b/node_modules/@artsy/fresnel/dist/Media.js
+@@ -140,8 +140,13 @@ function createMedia(config) {
+ 
+     var id = _react.default.useId();
+ 
+-    var isClient = typeof window !== "undefined";
+-    var isFirstRender = (0, _Utils.useIsFirstRender)();
++    var _React$useState = _react.default.useState(false),
++        hasHydrated = _React$useState[0],
++        setHasHydrated = _React$useState[1];
++
++    _react.default.useEffect(function () {
++      setHasHydrated(true);
++    }, []);
+     var className;
+ 
+     if (props.interaction) {
+@@ -163,45 +168,22 @@ function createMedia(config) {
+     var doesMatchParent = !mediaParentContext.hasParentMedia || (0, _Utils.intersection)(mediaQueries.breakpoints.toVisibleAtBreakpointSet(mediaParentContext.breakpointProps), mediaQueries.breakpoints.toVisibleAtBreakpointSet(breakpointProps)).length > 0;
+     var renderChildren = doesMatchParent && (onlyMatch === undefined || mediaQueries.shouldRenderMediaQuery(_objectSpread({}, breakpointProps, {
+       interaction: interaction
+-    }), onlyMatch)); // Append a unique id to the className (consistent on server and client)
++    }), onlyMatch));
++    var renderHydrationSafeChildren = hasHydrated ? renderChildren : doesMatchParent; // Append a unique id to the className (consistent on server and client)
+ 
+     var uniqueComponentId = " fresnel-".concat(id);
+     className += uniqueComponentId;
+-    /**
+-     * SPECIAL CASE:
+-     * If we're on the client, this is the first render, and we are not going
+-     * to render the children, we need to cleanup the the server-rendered HTML
+-     * to avoid a hydration mismatch on React 18+. We do this by grabbing the
+-     * already-existing element(s) directly from the DOM using the unique class
+-     * id and clearing its contents. This solution follows one of the
+-     * suggestions from Dan Abromov here:
+-     *
+-     * https://github.com/facebook/react/issues/23381#issuecomment-1096899474
+-     *
+-     * This will not have a negative impact on client-only rendering because
+-     * either 1) isFirstRender will be false OR 2) the element won't exist yet
+-     * so there will be nothing to clean up. It will only apply on SSR'd HTML
+-     * on initial hydration.
+-     */
+-
+-    if (isClient && isFirstRender && !renderChildren) {
+-      var containerEls = document.getElementsByClassName(uniqueComponentId);
+-      Array.from(containerEls).forEach(function (el) {
+-        return el.innerHTML = "";
+-      });
+-    }
+-
+     return _react.default.createElement(MediaParentContext.Provider, {
+       value: childMediaParentContext
+     }, function () {
+       if (props.children instanceof Function) {
+-        return props.children(className, renderChildren);
++        return props.children(className, renderHydrationSafeChildren);
+       } else {
+         return _react.default.createElement("div", {
+           className: ["fresnel-container", className, passedClassName].filter(Boolean).join(" "),
+           style: style,
+           suppressHydrationWarning: true
+-        }, renderChildren ? props.children : null);
++        }, renderHydrationSafeChildren ? props.children : null);
+       }
+     }());
+   };

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -856,7 +856,7 @@
     source-map "^0.5.7"
     stylis "4.2.0"
 
-"@emotion/cache@^11.14.0":
+"@emotion/cache@11.14.0", "@emotion/cache@^11.14.0":
   version "11.14.0"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.14.0.tgz#ee44b26986eeb93c8be82bb92f1f7a9b21b2ed76"
   integrity sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==
@@ -907,6 +907,16 @@
     "@emotion/utils" "^1.4.2"
     csstype "^3.0.2"
 
+"@emotion/server@11.11.0":
+  version "11.11.0"
+  resolved "https://registry.yarnpkg.com/@emotion/server/-/server-11.11.0.tgz#35537176a2a5ed8aed7801f254828e636ec3bd6e"
+  integrity sha512-6q89fj2z8VBTx9w93kJ5n51hsmtYuFPtZgnc1L8VzRx9ti4EU6EyvF6Nn1H1x3vcCQCF7u2dB2lY4AYJwUW4PA==
+  dependencies:
+    "@emotion/utils" "^1.2.1"
+    html-tokenize "^2.0.0"
+    multipipe "^1.0.2"
+    through "^2.3.8"
+
 "@emotion/sheet@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.4.0.tgz#c9299c34d248bc26e82563735f78953d2efca83c"
@@ -927,7 +937,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz#8a8cb77b590e09affb960f4ff1e9a89e532738bf"
   integrity sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==
 
-"@emotion/utils@^1.4.2":
+"@emotion/utils@^1.2.1", "@emotion/utils@^1.4.2":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.4.2.tgz#6df6c45881fcb1c412d6688a311a98b7f59c1b52"
   integrity sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==
@@ -2751,6 +2761,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -3131,6 +3146,11 @@ async-function@^1.0.0:
   resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
   integrity sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 auto-bind@~4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/auto-bind/-/auto-bind-4.0.0.tgz#e3589fc6c2da8f7ca43ba9f84fa52a744fc997fb"
@@ -3328,6 +3348,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+buffer-from@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-0.1.2.tgz#15f4b9bcef012044df31142c14333caf6e0260d0"
+  integrity sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==
+
 bytes@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a"
@@ -3431,7 +3456,7 @@ chalk@^2.0.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3518,6 +3543,11 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+ci-info@^3.7.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 classnames@2.5.1, classnames@^2.5.1:
   version "2.5.1"
@@ -3827,7 +3857,7 @@ cross-inspect@1.0.1:
   dependencies:
     tslib "^2.4.0"
 
-cross-spawn@^7.0.6:
+cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -4070,6 +4100,13 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     call-bind-apply-helpers "^1.0.1"
     es-errors "^1.3.0"
     gopd "^1.2.0"
+
+duplexer2@^0.1.2:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
+  integrity sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==
+  dependencies:
+    readable-stream "^2.0.2"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -4693,6 +4730,13 @@ find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flush-write-stream@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -4731,6 +4775,16 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+
+fs-extra@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-mkdirp-stream@^1.0.0:
   version "1.0.0"
@@ -4903,6 +4957,18 @@ glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global-dirs@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
@@ -4961,6 +5027,11 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6,
   version "4.2.9"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
+
+graceful-fs@^4.2.0:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 graphemer@^1.4.0:
   version "1.4.0"
@@ -5116,6 +5187,17 @@ html-parse-stringify@^3.0.1:
   dependencies:
     void-elements "3.1.0"
 
+html-tokenize@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-tokenize/-/html-tokenize-2.0.1.tgz#c3b2ea6e2837d4f8c06693393e9d2a12c960be5f"
+  integrity sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==
+  dependencies:
+    buffer-from "~0.1.1"
+    inherits "~2.0.1"
+    minimist "~1.2.5"
+    readable-stream "~1.0.27-1"
+    through2 "~0.4.1"
+
 http-cache-semantics@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
@@ -5242,7 +5324,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5390,6 +5472,11 @@ is-date-object@^1.0.5, is-date-object@^1.1.0:
   dependencies:
     call-bound "^1.0.2"
     has-tostringtag "^1.0.2"
+
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
@@ -5636,10 +5723,22 @@ is-windows@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
+is-wsl@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
+
 is-yarn-global@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
   integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -5752,6 +5851,17 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-stable-stringify@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz#8903cfac42ea1a0f97f35d63a4ce0518f0cc6a70"
+  integrity sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    isarray "^2.0.5"
+    jsonify "^0.0.1"
+    object-keys "^1.1.1"
+
 json-to-pretty-yaml@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz#f4cd0bd0a5e8fe1df25aaf5ba118b099fd992d5b"
@@ -5786,6 +5896,20 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jsonfile@^6.0.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.2.1.tgz#b6e31717f22cc37330b081ce0051ed5de53af2f6"
+  integrity sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.5:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz#4766bd05a8e2a11af222becd19e15575e52a853a"
@@ -5807,6 +5931,13 @@ kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 language-subtag-registry@^0.3.20:
   version "0.3.23"
@@ -6010,7 +6141,7 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -6052,6 +6183,13 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^3.1.1:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -6071,7 +6209,7 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-minimist@^1.2.6:
+minimist@^1.2.6, minimist@~1.2.5:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -6095,6 +6233,14 @@ ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+multipipe@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/multipipe/-/multipipe-1.0.2.tgz#cc13efd833c9cda99f224f868461b8e1a3fd939d"
+  integrity sha512-6uiC9OvY71vzSGX8lZvSqscE7ft9nPupJ8fMjrCNRAUy2LREUW42UL+V/NTrogr6rFgRydUrCX4ZitfpSNkSCQ==
+  dependencies:
+    duplexer2 "^0.1.2"
+    object-assign "^4.1.0"
 
 mute-stream@^2.0.0:
   version "2.0.0"
@@ -6296,6 +6442,11 @@ object-keys@^1.0.12, object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
+object-keys@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
+  integrity sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==
+
 object.assign@^4.0.4:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
@@ -6378,6 +6529,14 @@ onetime@^7.0.0:
   dependencies:
     mimic-function "^5.0.0"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
@@ -6396,6 +6555,11 @@ ordered-read-streams@^1.0.0:
   integrity sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=
   dependencies:
     readable-stream "^2.0.1"
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
 own-keys@^1.0.1:
   version "1.0.1"
@@ -6498,6 +6662,27 @@ pascal-case@^3.1.2:
   dependencies:
     no-case "^3.0.4"
     tslib "^2.0.3"
+
+patch-package@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.0.tgz#d191e2f1b6e06a4624a0116bcb88edd6714ede61"
+  integrity sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    ci-info "^3.7.0"
+    cross-spawn "^7.0.3"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^9.0.0"
+    json-stable-stringify "^1.0.2"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^7.5.3"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^2.2.2"
 
 path-case@^3.0.4:
   version "3.0.4"
@@ -6824,25 +7009,7 @@ rc-menu@~9.16.0, rc-menu@~9.16.1:
     rc-overflow "^1.3.1"
     rc-util "^5.27.0"
 
-rc-motion@^2.0.0, rc-motion@^2.0.1, rc-motion@^2.3.0, rc-motion@^2.3.4, rc-motion@^2.4.3, rc-motion@^2.4.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.4.4.tgz#e995d5fa24fc93065c24f714857cf2677d655bb0"
-  integrity sha512-ms7n1+/TZQBS0Ydd2Q5P4+wJTSOrhIrwNxLXCZpR7Fa3/oac7Yi803HDALc2hLAKaCTQtw9LmQeB58zcwOsqlQ==
-  dependencies:
-    "@babel/runtime" "^7.11.1"
-    classnames "^2.2.1"
-    rc-util "^5.2.1"
-
-rc-motion@^2.6.1, rc-motion@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.6.2.tgz#3d31f97e41fb8e4f91a4a4189b6a98ac63342869"
-  integrity sha512-4w1FaX3dtV749P8GwfS4fYnFG4Rb9pxvCYPc/b2fw1cmlHJWNNgOFIz7ysiD+eOrzJSvnLJWlNQQncpNMXwwpg==
-  dependencies:
-    "@babel/runtime" "^7.11.1"
-    classnames "^2.2.1"
-    rc-util "^5.21.0"
-
-rc-motion@^2.9.0, rc-motion@^2.9.5:
+rc-motion@2.9.5, rc-motion@^2.0.0, rc-motion@^2.0.1, rc-motion@^2.3.0, rc-motion@^2.3.4, rc-motion@^2.4.3, rc-motion@^2.4.4, rc-motion@^2.6.1, rc-motion@^2.6.2, rc-motion@^2.9.0, rc-motion@^2.9.5:
   version "2.9.5"
   resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.9.5.tgz#12c6ead4fd355f94f00de9bb4f15df576d677e0c"
   integrity sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==
@@ -6910,17 +7077,7 @@ rc-rate@~2.13.1:
     classnames "^2.2.5"
     rc-util "^5.0.1"
 
-rc-resize-observer@^1.0.0, rc-resize-observer@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/rc-resize-observer/-/rc-resize-observer-1.2.0.tgz#9f46052f81cdf03498be35144cb7c53fd282c4c7"
-  integrity sha512-6W+UzT3PyDM0wVCEHfoW3qTHPTvbdSgiA43buiy8PzmeMnfgnDeb9NjdimMXMl3/TcrvvWl5RRVdp+NqcR47pQ==
-  dependencies:
-    "@babel/runtime" "^7.10.1"
-    classnames "^2.2.1"
-    rc-util "^5.15.0"
-    resize-observer-polyfill "^1.5.1"
-
-rc-resize-observer@^1.3.1, rc-resize-observer@^1.4.0, rc-resize-observer@^1.4.3:
+rc-resize-observer@1.4.3, rc-resize-observer@^1.0.0, rc-resize-observer@^1.1.0, rc-resize-observer@^1.3.1, rc-resize-observer@^1.4.0, rc-resize-observer@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz#4fd41fa561ba51362b5155a07c35d7c89a1ea569"
   integrity sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==
@@ -7057,34 +7214,7 @@ rc-upload@~4.9.2:
     classnames "^2.2.5"
     rc-util "^5.2.0"
 
-rc-util@^5.0.1, rc-util@^5.15.0, rc-util@^5.16.1, rc-util@^5.2.0, rc-util@^5.2.1:
-  version "5.16.1"
-  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.16.1.tgz#374db7cb735512f05165ddc3d6b2c61c21b8b4e3"
-  integrity sha512-kSCyytvdb3aRxQacS/71ta6c+kBWvM1v8/2h9d/HaNWauc3qB8pLnF20PJ8NajkNN8gb+rR1l0eWO+D4Pz+LLQ==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    react-is "^16.12.0"
-    shallowequal "^1.1.0"
-
-rc-util@^5.17.0, rc-util@^5.18.1, rc-util@^5.20.1, rc-util@^5.21.0:
-  version "5.23.0"
-  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.23.0.tgz#a583b1ec3e1832a80eced7a700a494af0b590743"
-  integrity sha512-lgm6diJ/pLgyfoZY59Vz7sW4mSoQCgozqbBye9IJ7/mb5w5h4T7h+i2JpXAx/UBQxscBZe68q0sP7EW+qfkKUg==
-  dependencies:
-    "@babel/runtime" "^7.18.3"
-    react-is "^16.12.0"
-    shallowequal "^1.1.0"
-
-rc-util@^5.24.4:
-  version "5.24.4"
-  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.24.4.tgz#a4126f01358c86f17c1bf380a1d83d6c9155ae65"
-  integrity sha512-2a4RQnycV9eV7lVZPEJ7QwJRPlZNc06J7CwcwZo4vIHr3PfUqtYgl1EkUV9ETAc6VRRi8XZOMFhYG63whlIC9Q==
-  dependencies:
-    "@babel/runtime" "^7.18.3"
-    react-is "^16.12.0"
-    shallowequal "^1.1.0"
-
-rc-util@^5.25.2, rc-util@^5.27.0, rc-util@^5.30.0, rc-util@^5.31.1, rc-util@^5.32.2, rc-util@^5.34.1, rc-util@^5.35.0, rc-util@^5.36.0, rc-util@^5.37.0, rc-util@^5.38.0, rc-util@^5.38.1, rc-util@^5.40.1, rc-util@^5.43.0, rc-util@^5.44.0, rc-util@^5.44.1, rc-util@^5.44.3, rc-util@^5.44.4:
+rc-util@5.44.4, rc-util@^5.0.1, rc-util@^5.16.1, rc-util@^5.17.0, rc-util@^5.18.1, rc-util@^5.2.0, rc-util@^5.20.1, rc-util@^5.21.0, rc-util@^5.24.4, rc-util@^5.25.2, rc-util@^5.27.0, rc-util@^5.30.0, rc-util@^5.31.1, rc-util@^5.32.2, rc-util@^5.34.1, rc-util@^5.35.0, rc-util@^5.36.0, rc-util@^5.37.0, rc-util@^5.38.0, rc-util@^5.38.1, rc-util@^5.40.1, rc-util@^5.43.0, rc-util@^5.44.0, rc-util@^5.44.1, rc-util@^5.44.3, rc-util@^5.44.4:
   version "5.44.4"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.44.4.tgz#89ee9037683cca01cd60f1a6bbda761457dd6ba5"
   integrity sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==
@@ -7135,7 +7265,7 @@ react-infinite-scroller@^1.2.4:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -7178,6 +7308,29 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.5, readable
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@^2.0.2:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@~1.0.17, readable-stream@~1.0.27-1:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -7357,6 +7510,13 @@ rfdc@^1.4.1:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -7456,6 +7616,11 @@ semver@^7.3.4:
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.5.3:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 semver@^7.6.0, semver@^7.7.1, semver@^7.7.2:
   version "7.7.2"
@@ -7559,11 +7724,6 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
-
-shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 sharp@^0.34.3:
   version "0.34.3"
@@ -7684,6 +7844,11 @@ sirv@^2.0.3:
     "@polka/url" "^1.0.0-next.24"
     mrmime "^2.0.0"
     totalist "^3.0.0"
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -7889,6 +8054,11 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -8038,6 +8208,19 @@ through2@^3.0.1:
     inherits "^2.0.4"
     readable-stream "2 || 3"
 
+through2@~0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.4.2.tgz#dbf5866031151ec8352bb6c4db64a2292a840b9b"
+  integrity sha512-45Llu+EwHKtAZYTPPVn3XZHBgakWMN3rokhEv5hu596XP+cNgplMg+Gj+1nmAvj+L0K7+N49zBKx5rah5u0QIQ==
+  dependencies:
+    readable-stream "~1.0.17"
+    xtend "~2.1.1"
+
+through@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
+
 timeout-signal@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/timeout-signal/-/timeout-signal-2.0.0.tgz#23207ea448d50258bb0defe3beea4a467643abba"
@@ -8057,6 +8240,13 @@ title-case@^3.0.3:
   integrity sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==
   dependencies:
     tslib "^2.0.3"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 to-absolute-glob@^2.0.0:
   version "2.0.2"
@@ -8304,6 +8494,11 @@ unique-string@^2.0.0:
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
+
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
 unixify@^1.0.0:
   version "1.0.0"
@@ -8692,6 +8887,13 @@ xdg-basedir@^4.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
+xtend@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
+  integrity sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==
+  dependencies:
+    object-keys "~0.4.0"
+
 xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
@@ -8721,6 +8923,11 @@ yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yaml@^2.2.2:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yaml@^2.3.1:
   version "2.8.1"


### PR DESCRIPTION
## Summary

- make Fresnel's first client render match its SSR output under React 19, then apply the active breakpoint after hydration
- extract Emotion and Ant Design critical CSS during Pages Router SSR so styles are present in `<head>` on the first response
- share one Ant Design cache per render and remove nested App Router registries from the desktop and mobile layouts
- place Ant Design defaults in a cascade layer so existing Dofuslab Emotion overrides retain their intended precedence

## Root cause

Fresnel 8.x clears server-rendered media contents directly before React hydrates. React 19 treats that mutation as a recoverable hydration mismatch and regenerates the tree on the client.

Separately, Emotion styles were emitted inside the rendered body, while nested `AntdRegistry` instances hid Ant Design rules from the cache extracted by `_document`. Consolidating the SSR caches removes the unstyled first render. Ant may relocate its extracted stylesheet during client initialization, so its defaults are layered below the application's unlayered Emotion rules to keep the original visual styling.

## Impact

Local development no longer shows the hydration failure overlay or the application-level FOUC. Existing navigation colors, stat spacing, and control sizing continue to come from Dofuslab's styles rather than later-inserted Ant defaults.

## Validation

- `yarn install` — Fresnel patch reapplies successfully
- `yarn type-check --pretty false`
- local Next.js dev response and browser verification: no hydration mismatch; Emotion and Ant critical CSS emitted in `<head>`; no body style tags
- `yarn build` compiled successfully; static export later stopped on `/default/equip/set` because the local GraphQL endpoint returned HTTP 400 during prerendering
