### PR TITLE
Match Safari browser chrome to the dark theme

### DIFF
--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -50,7 +50,8 @@ const DofusLabDocument = ({ __NEXT_DATA__ }: DocumentProps) => {
         />
         <link rel="stylesheet" href="/twicon/twicon.css" />
         <meta name="msapplication-TileColor" content="#da532c" />
-        <meta name="theme-color" content="#ffffff" />
+        <meta name="theme-color" content="#1f1f1f" />
+        <meta name="color-scheme" content="dark" />
         {/* Global Site Tag (gtag.js) - Google Analytics */}
         <script
           async


### PR DESCRIPTION
## Summary

- change the browser `theme-color` from white to DofusLab's dark header color (`#1f1f1f`)
- declare the document's supported color scheme as dark

## Why

iPhone Safari was rendering a white bar above the DofusLab logo and navigation. The page metadata explicitly advertised `#ffffff` as its theme color even though DofusLab is dark-theme only, causing Safari's surrounding browser chrome to clash with the application.

## Impact

Safari and other supporting browsers can now blend their browser chrome into DofusLab's dark header. The dark color-scheme declaration also gives browser-provided UI the correct dark appearance.

## Validation

- `prettier --check client/pages/_document.tsx`
- `eslint client/pages/_document.tsx`
- `git diff --check`
